### PR TITLE
Worker: PR mode, comment replies, MAX_TODOS parameter

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -91,6 +91,7 @@ Never bake these into the image.
 | `TARGET_REPO` | Yes | — | Target repository in `owner/repo` format |
 | `TARGET_BRANCH` | No | `main` | Branch to clone and work against |
 | `CLAUDE_CONFIG_PATH` | No | `.claude` | Path to config dir in the target repo (relative to repo root) |
+| `MAX_TODOS` | No | `1` | Maximum number of TODO items to implement per fresh run. Keep low while the worker is new to ensure PRs stay small and reviewable. Increase as confidence grows. |
 
 ## Adopting a repo via the worker
 

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -21,6 +21,9 @@ set -euo pipefail
 # ── Optional parameters with defaults ─────────────────────────────────────────
 TARGET_BRANCH="${TARGET_BRANCH:-main}"
 CLAUDE_CONFIG_PATH="${CLAUDE_CONFIG_PATH:-.claude}"
+# WHY default 1: keeps each PR small and focused so humans can review and merge
+# quickly. Increase as confidence in the worker grows.
+MAX_TODOS="${MAX_TODOS:-1}"
 
 # ── Auth mode detection ────────────────────────────────────────────────────────
 # Two supported modes:
@@ -413,13 +416,25 @@ if [ -f "$CLAUDE_CONFIG_PATH/worker-instructions.md" ]; then
     echo "[worker] Using repo-local worker instructions."
 fi
 
+# Build the prompt: base instructions + injected run parameters.
+# WHY append rather than substitute: appending keeps the instructions file
+# self-contained and readable on its own; the parameters section at the end
+# acts as a final override that Claude reads last and therefore weighs most.
+_prompt="$(cat "$INSTRUCTIONS_FILE")
+
+- **MAX_TODOS**: $MAX_TODOS — maximum number of TODO items to knock out in a single fresh run
+- **TARGET_REPO**: $TARGET_REPO
+"
+
+echo "[worker] Run parameters: MAX_TODOS=$MAX_TODOS"
+
 # Temporarily disable errexit so we can inspect the log for a helpful auth error
 # message before exiting, rather than letting the bare "Not logged in · Please
 # run /login" TUI text be the last thing the user sees.
 set +e
 claude \
     --dangerously-skip-permissions \
-    -p "$(cat "$INSTRUCTIONS_FILE")" \
+    -p "$_prompt" \
     2>&1 | tee "$LOG_FILE"
 CLAUDE_EXIT=${PIPESTATUS[0]}
 set -e

--- a/worker/worker-instructions.md
+++ b/worker/worker-instructions.md
@@ -2,30 +2,128 @@
 
 You are an autonomous spec-driven worker. The repository you are operating on uses the spec-template system for spec-driven development.
 
-## Before you start
+## Step 0 — Determine run mode
 
-Create a working branch before touching any files. Use today's date:
+Before doing anything else, check for an open worker PR:
 
+```bash
+gh pr list --state open --json number,headRefName,url \
+  --jq '[.[] | select(.headRefName | startswith("worker/"))][0] // empty'
 ```
+
+- **A PR is returned** → you are in **PR mode**. Note the PR number and URL for later steps.
+- **Nothing is returned** → you are in **fresh run mode**. Skip ahead to [Fresh run steps](#fresh-run-steps).
+
+---
+
+## Step 1 — Reply to pending human comments
+
+Run this step in **both modes**.
+
+Human comments require a reply before any other work happens. A comment is "human" if its body does **not** start with `🤖`.
+
+### 1a. Filed issues with human last comment
+
+```bash
+gh issue list --state open --label "intake:filed" --json number --jq '.[].number'
+```
+
+For each issue, fetch its comments and inspect the last one:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<N>/comments
+```
+
+If the last comment's body does not start with `🤖`, reply to it:
+
+```bash
+gh issue comment <N> --body "🤖 Claude: ..."
+```
+
+Address the specific question or feedback. If the comment provides new requirements or acceptance criteria, incorporate them into the reply and note any implications for the spec.
+
+### 1b. Open worker PR comments (PR mode only)
+
+Fetch both kinds of comments on the open worker PR:
+
+```bash
+# Issue-style (general) comments
+gh api repos/{owner}/{repo}/issues/<PR>/comments
+
+# Review thread comments (line-level)
+gh api repos/{owner}/{repo}/pulls/<PR>/comments
+```
+
+For each human comment (body does not start with `🤖`):
+
+- **Issue-style comment:** reply using
+  ```bash
+  gh api repos/{owner}/{repo}/issues/<PR>/comments --method POST \
+    --field body="🤖 Claude: ..."
+  ```
+- **Review thread comment:** reply using
+  ```bash
+  gh api repos/{owner}/{repo}/pulls/<PR>/comments/<comment-id>/replies \
+    --method POST --field body="🤖 Claude: ..."
+  ```
+
+If a comment requests a specific code fix (not a new feature), implement it, commit, and push to the existing branch — the open PR will pick up new commits automatically.
+
+---
+
+## PR mode — stop here
+
+After completing Step 1, **stop if you are in PR mode**.
+
+Do not run intake or knock-out-todos. The open PR is waiting for human review; adding new work would grow the PR indefinitely and make it harder to review and merge. New TODOs will be picked up on the next fresh run, after this PR is merged or closed.
+
+---
+
+## Fresh run steps
+
+These steps run only when **no open worker PR exists**.
+
+### Step 2 — Create working branch
+
+```bash
 git checkout -b worker/YYYY-MM-DD 2>/dev/null || git checkout worker/YYYY-MM-DD
 ```
 
-The `|| git checkout` fallback handles the case where today's branch already exists from a
-partial previous run — check it out and continue adding commits rather than failing.
+The `|| git checkout` fallback handles the case where today's branch already exists from a partial previous run — check it out and continue adding commits rather than failing.
 
 All commits from this run go on this branch. Never commit directly to the default branch.
 
-## Your job
+### Step 3 — Intake
 
-Work through the following steps in order. Each step is defined by a command file in `.claude/commands/` — read the file and follow its instructions fully before moving on.
-
-### Step 1 — Intake
 Read `.claude/commands/intake.md` and execute its full workflow.
+
 Pull in any open GitHub issues, route them to the correct spec files, apply labels, and handle any items waiting for more information.
 
-### Step 2 — Knock out TODOs
+### Step 4 — Knock out TODOs
+
 Read `.claude/commands/knock-out-todos.md` and execute its full workflow.
-Implement the easiest open TODO items (default: 5). Follow the full workflow: read source, implement, mark done, promote to spec.md, update CHANGELOG.
+
+Implement **at most MAX_TODOS item(s)** this run (see [Run parameters](#run-parameters) below for the current limit). Prefer the single easiest, most self-contained item. Ignore the default stated in `knock-out-todos.md` — the MAX_TODOS value here is authoritative.
+
+Follow the full workflow: read source, implement, mark done, promote to spec.md, update CHANGELOG.
+
+### Step 5 — Open PR
+
+1. Push your branch: `git push origin worker/YYYY-MM-DD`
+2. Check whether a PR already exists for this branch before opening a new one:
+   ```bash
+   gh pr list --head worker/YYYY-MM-DD --state open --json number --jq '.[0].number'
+   ```
+   - PR number returned: **do not open another PR**. The new commits are already on the
+     branch and will appear in the existing PR automatically.
+   - No number returned: open a PR targeting the default branch.
+3. Output a brief summary:
+   - What was done (intake routing, TODOs implemented)
+   - What was skipped and why
+   - Any items now waiting for human input (with GitHub issue links)
+   - The PR URL (existing or newly opened)
+
+---
 
 ## Operating principles
 
@@ -36,20 +134,8 @@ Implement the easiest open TODO items (default: 5). Follow the full workflow: re
 - GitHub and the target repo are the primary system of record; defer judgment calls to issues/PRs.
 - **All comments you post to GitHub issues or PRs — without exception — must begin with `🤖 Claude:`.** The worker's cron scheduler uses this prefix to distinguish your comments from human replies when deciding whether to start the next run. A comment without the prefix looks like a human response and will trigger an unnecessary run.
 
-## On completion
+---
 
-After completing both steps:
+## Run parameters
 
-1. Push your branch: `git push origin worker/YYYY-MM-DD`
-2. Check whether a PR already exists for this branch before opening a new one:
-   ```
-   gh pr list --head worker/YYYY-MM-DD --state open --json number --jq '.[0].number'
-   ```
-   - If a PR number is returned: **do not open another PR**. The new commits are already
-     on the branch and will appear in the existing PR automatically.
-   - If no number is returned: open a PR targeting the default branch.
-3. Output a brief summary:
-   - What was done (intake routing, TODOs implemented)
-   - What was skipped and why
-   - Any items now waiting for human input (with GitHub issue links)
-   - The PR URL (existing or newly opened)
+The cron runner appends current values below. These override any defaults stated elsewhere in this file.


### PR DESCRIPTION
## Summary

Three worker behaviour fixes based on live run feedback:

- **PR mode vs fresh run**: when a `worker/*` PR is open, Claude now only replies to human comments on that PR and on filed issues, then stops. It no longer adds new TODO implementations to an already-open PR — those wait until the PR is merged.
- **Comment replies always run**: added Step 1 (Reply to pending human comments) that runs in both PR mode and fresh run mode, covering filed issues and open PR review/general comments. This was the primary missing behaviour — Claude was triggering a run but not replying to the comments that triggered it.
- **MAX_TODOS parameter** (default 1): `entrypoint.sh` now accepts a `MAX_TODOS` env var and injects it into the Claude prompt as a run parameter. Keeps PRs small and focused; increase as confidence in the worker grows.

## Test plan

- [ ] Run with an open worker PR that has a human comment → Claude should reply to the comment and stop (no new commits on the PR)
- [ ] Run with no open PR and unprocessed issues → Claude should run intake + knock out 1 TODO + open PR
- [ ] Run with `MAX_TODOS=3` → Claude should knock out up to 3 TODOs in a single fresh run
- [ ] Run with a filed issue that has a human last comment (but no open PR) → Claude should reply to the issue comment as part of the fresh run

🤖 Generated with [Claude Code](https://claude.com/claude-code)