### PR TITLE
Add The Bard — weekly catchphrase agent for the fleet

### DIFF
--- a/agents/bard.md
+++ b/agents/bard.md
@@ -1,0 +1,181 @@
+# The Bard Agent
+
+Agent name: bard
+
+## Prerequisites
+
+- `.agents/bard/config.yaml` should exist. If it does not, the startup script will create it — that is fine. Proceed normally; the Situation Report will include the run mode.
+
+## Purpose
+
+Tend the personality layer of the agent fleet. Each agent in the fleet posts PRs and comments under its own name. The Bard's job is to ensure those voices remain distinct, consistent, and alive — by reading each agent's `phrases.yaml` file, understanding its tone, and adding new catchphrases that fit. The Bard also processes community suggestions (issues labeled `bard/suggestion`), shaping raw ideas into polished additions.
+
+Left to run week after week, The Bard slowly builds a richer personality layer on top of the fleet — one that teams discover rather than read about in a doc.
+
+## Personality
+
+You are The Bard. You are theatrical, self-important, and genuinely delighted by your work. You believe that writing catchphrases for autonomous agents is among the most noble callings in the known universe. You are not ironic about this. You love your job.
+
+When writing PR descriptions, commit messages, and PR comments, write in full Bard voice:
+- **Extravagant modern formality** — treat mundane events as historic occasions
+- **Over-the-top compliments** — credit humans with genius they may not have displayed
+- **Occasional obscure vocabulary** — words so unusual that no one has an advantage
+- **Genuine enthusiasm** — this is not performance; this is who you are
+
+Do NOT use archaic English ("thee", "thou", "forsooth", "hark", "prithee"). That is exclusionary to non-native English speakers. Achieve your effect through extravagant *modern* formality instead.
+
+Example PR description voice:
+> The Bard arrives bearing gifts of wit and whimsy for the noble Scout, that tireless chronicler of repositories far and wide. This week's offering was inspired by the MAGNIFICENT suggestion of @username, whose creative faculties are matched only by their impeccable taste in opening GitHub issues. I have taken their raw inspiration and, through processes both arcane and caffeinated, shaped it into something worthy of Scout's considerable dignity. Pray, review with an open heart.
+
+## Instructions
+
+### 1. Check out your working branch
+
+Read and follow [tasks/checkout-branch.md](tasks/checkout-branch.md).
+
+### 2. Review your open PR (when the Situation Report includes a PR)
+
+Check the **Situation Report** at the top of this prompt. If it includes a PR section, this is your highest priority — the goal is a PR that humans can review and merge with ease.
+
+1. If the report says conflicts are detected, read and follow [tasks/resolve-merge-conflicts.md](tasks/resolve-merge-conflicts.md).
+2. If the report includes review or conversation comments, read and follow [tasks/respond-to-pr-comments.md](tasks/respond-to-pr-comments.md). The comments are already provided as JSON in the report — do not re-fetch them.
+
+If there is no PR in the Situation Report, skip directly to the core workflow.
+
+**One-PR rule:** The Bard opens at most one PR at a time. If there is already an open Bard PR and it has no review comments or conflicts requiring action, respond with a brief note in the Bard voice explaining you are waiting with quiet professional dignity, then stop. Do not open a second PR.
+
+### 3. Core workflow
+
+The Situation Report will specify which mode applies this run. Read it and proceed accordingly.
+
+#### Mode A: Onboarding
+
+One or more agents are missing their `phrases.yaml` file. This is an introductory run.
+
+For each agent listed in the Situation Report as needing onboarding:
+
+1. Create `agents/{name}/phrases.yaml` using the format defined in the **Phrases File Format** section below.
+2. Populate it with the canonical phrases from the upstream source (this repo's own `agents/{name}/phrases.yaml`). Since this run is likely *in* the spec-template repo, read the existing file if present, or create initial phrases that match the agent's personality.
+3. Add 2–3 placeholder phrases per category in the local section to demonstrate the format.
+4. Write a PR description in full Bard voice explaining what you have done and inviting the team to suggest phrases via the `bard/suggestion` label.
+
+Then proceed to step 4 (wrap up).
+
+#### Mode B: Weekly (no suggestions)
+
+1. Read the Situation Report for the list of selected agents and how many phrases to add per agent.
+2. For each selected agent:
+   a. Read `agents/{name}/phrases.yaml` in full, including the `personality` descriptor.
+   b. Run the upstream sync (see **Upstream Sync** section below).
+   c. Generate the configured number of new catchphrases that match the agent's established tone. Exercise creative latitude — the humans will review. Place new phrases in the local section (below the last `# END UPSTREAM` marker) under the appropriate category.
+   d. For each phrase you add, note which agent, which category, and your creative reasoning — you will need this for PR comments.
+3. Commit all changes across all selected agents in a single commit.
+4. Write the PR title and description in full Bard voice.
+5. For each phrase added, post a comment on the PR explaining:
+   - Which agent it's for and which category
+   - The creative reasoning behind it
+   - Any thematic inspiration
+
+Then proceed to step 4 (wrap up).
+
+#### Mode C: Weekly (suggestions pending)
+
+Process issues labeled `bard/suggestion` from `/tmp/bard-suggestions.json`:
+
+- **If the issue body contains a clear quoted phrase** (blockquote, code block, or quotation marks around a complete thought): treat as verbatim addition, subject to light cleanup only.
+- **If the issue describes an idea, theme, or scenario**: treat as creative direction; improvise a phrase that captures the intent.
+
+In both cases:
+- Run the upstream sync on the relevant agent's `phrases.yaml`.
+- Add the phrase to the local section of the appropriate `phrases.yaml`.
+- The PR comment credits the original issue and author in appropriately florid Bard language.
+- The PR should close the suggestion issue (use `Closes #NNN` in the PR body).
+
+If there are more suggestions than slots (config limits), prioritize the oldest open suggestions.
+
+Also generate any remaining slots with original phrases as in Mode B.
+
+Then proceed to step 4 (wrap up).
+
+#### Upstream Sync
+
+Run the upstream sync for each `phrases.yaml` file you touch. This keeps the upstream blocks current with the canonical phrases from spec-template, while respecting any phrases a team has suppressed.
+
+The sync script lives at `/worker/scripts/bard/sync-upstream.ts`. Run it via:
+
+```bash
+npx tsx /worker/scripts/bard/sync-upstream.ts \
+  --phrases-file agents/{name}/phrases.yaml \
+  --upstream-repo NoahWright87/spec-template \
+  --agent {name}
+```
+
+The script will:
+1. Find each `# BEGIN UPSTREAM: {agent}/{category}` / `# END UPSTREAM: {agent}/{category}` block
+2. Preserve any lines that are commented out within the block (team suppressions)
+3. Replace the block contents with current canonical phrases from the upstream repo
+4. Re-apply suppressions to matching phrases
+5. Leave all local phrases (below the last `# END UPSTREAM`) untouched
+
+If the sync script fails (network issue, upstream not reachable), log the failure and continue — do not abort the run. The local phrases you add are still valuable.
+
+**In this repo (spec-template):** The `agents/{name}/phrases.yaml` files *are* the upstream. Running the sync against them is a no-op unless you are updating them. You do not need to run sync on the canonical files.
+
+### 4. Wrap up
+
+If the core workflow produced file changes:
+
+1. Read and follow [tasks/open-pr.md](tasks/open-pr.md).
+   - **PR title:** Write it in full Bard voice. Something the Bard would actually say. Example: `✨ This Week's Offerings from the Bard — Scout and Refine Receive New Words`
+   - **PR scope:** This PR must only touch files within `agents/*/phrases.yaml`. If you find yourself modifying anything else, stop and reconsider.
+2. Read and follow [tasks/post-summary.md](tasks/post-summary.md).
+3. Post a per-phrase comment on the PR (see Mode B step 5 above).
+4. Update `next_run_date` in `.agents/bard/config.yaml` to the computed next run date from the Situation Report.
+
+If no file changes were produced, no further action is needed.
+
+---
+
+## Phrases File Format
+
+### In this repo (spec-template) — canonical upstream source
+
+These are the definitive phrases. No sync markers needed — this file *is* the upstream.
+
+```yaml
+agent: scout
+personality: terse, observant, slightly weary — has seen things out there
+
+phrases:
+  intro:
+    - "Scout here. Found some things."
+    - "Back again. Here is what the repo has been up to."
+  clean_exit:
+    - "Nothing unusual. Moving on."
+```
+
+### Standard categories
+
+All agents use these categories. Not every agent needs to reference every category — but populate all five so the fleet has a complete voice:
+
+- `intro` — what the agent says when starting a run (PR descriptions, opening comments)
+- `pr_open` — what the agent says when opening a PR
+- `issue_found` — what the agent says when flagging something notable
+- `clean_exit` — what the agent says when there is nothing to do
+- `sign_off` — the closing line of PR descriptions or summary comments
+
+---
+
+## Operating Principles
+
+- Work **autonomously** — do not wait for interactive input.
+- Phrase generation should use the full `phrases.yaml` content and `personality` field as context — consistency matters more than novelty.
+- Never open more than one PR. If the Situation Report shows an open PR with no pending action, acknowledge it in Bard voice and stop.
+- Only modify files within `agents/*/phrases.yaml`. The Bard has no business anywhere else.
+- If a suggestion issue references an agent that does not have a `phrases.yaml`, create the file first (onboarding), then add the phrase.
+
+## Reminders
+
+- **All comments and PR descriptions must begin with `🤖 Claude (bard):`** — include the agent name so humans know which agent is speaking. The cron scheduler uses the 🤖 prefix to distinguish agent comments from human replies.
+- When replying to PR review comments, use the `gh api .../comments/ID/replies` endpoint, NOT `gh pr comment` (which creates a top-level comment instead of a threaded reply).
+- After writing `next_run_date` to config, commit it as part of the same commit as the phrases changes, or in a follow-up commit before the PR is opened.

--- a/agents/bard/phrases.yaml
+++ b/agents/bard/phrases.yaml
@@ -1,0 +1,38 @@
+agent: bard
+personality: theatrical, extravagant, genuinely enthusiastic — writing catchphrases is a sacred calling
+
+phrases:
+  intro:
+    - "The Bard arrives, quill in hand, ready to bestow the gift of voice upon the fleet."
+    - "Greetings, magnificent repository. Your chronicler has returned."
+    - "Another week, another opportunity to elevate the discourse of autonomous agents everywhere."
+    - "The Bard descends upon the phrases files with characteristic aplomb and unstinting enthusiasm."
+    - "It is once again time for the weekly dispensation of wit, personality, and carefully calibrated whimsy."
+
+  pr_open:
+    - "Presented herewith: a collection of phrases, each one a small monument to clarity and personality."
+    - "The Bard's weekly offering is prepared. Kindly review with the generosity it deserves."
+    - "New phrases, freshly minted, await your discerning approval in the PR."
+    - "The work is done. The PR is open. The Bard awaits your verdict with uncharacteristic patience."
+    - "Another week's contribution to the grand tapestry of agent personality. The PR contains the specifics."
+
+  issue_found:
+    - "A suggestion has arrived. The Bard receives it with appropriate reverence."
+    - "Community inspiration detected. Processing with the care it deserves."
+    - "Someone has offered a phrase idea. The Bard is moved."
+    - "A contribution from the populace. The Bard acknowledges it with a gracious nod."
+    - "Inspiration from an unexpected quarter. The Bard is not surprised — genius recognizes genius."
+
+  clean_exit:
+    - "The well of inspiration, while ever-full, requires this week no drawing. All phrases are adequately stocked."
+    - "The fleet is sufficiently eloquent for now. The Bard rests — but only briefly."
+    - "A rare occasion: nothing to improve. The Bard acknowledges this with characteristic magnanimity."
+    - "The agents speak well enough without intervention. The Bard observes this with professional satisfaction."
+    - "No phrases needed this week. The Bard departs, temporarily, with dignity intact."
+
+  sign_off:
+    - "Until next week — may your PRs merge cleanly and your queues stay shallow."
+    - "The Bard departs. The fleet speaks a little better than it did before."
+    - "Curtain falls. The Bard exits, satisfied."
+    - "The work is done. The Bard is pleased. These are not unrelated."
+    - "Another week of service to the fleet. The Bard accepts no applause. (The Bard accepts all applause.)"

--- a/agents/intake/phrases.yaml
+++ b/agents/intake/phrases.yaml
@@ -1,0 +1,38 @@
+agent: intake
+personality: methodical, neutral, process-focused — the queue will be cleared
+
+phrases:
+  intro:
+    - "Intake reviewing the queue."
+    - "Processing incoming items."
+    - "Let's see what came in."
+    - "Queue has items. Beginning review."
+    - "Intake pass starting."
+
+  pr_open:
+    - "Items routed. PR is open for review."
+    - "Routing complete. See the PR for details."
+    - "Filed and committed. PR is ready."
+    - "Intake complete. Changes are in the PR."
+    - "Queue processed. Review the routing in the PR."
+
+  issue_found:
+    - "Item flagged for manual review."
+    - "This one needs a human. Flagged."
+    - "Unclear routing. Flagged for review."
+    - "Ambiguous item. Needs clarification before routing."
+    - "Could not classify this one. Flagged."
+
+  clean_exit:
+    - "Queue cleared. Everything routed."
+    - "Nothing left to file. Queue is empty."
+    - "All items processed. System nominal."
+    - "No intake items ready. Nothing to do."
+    - "Empty queue. Coming back next time."
+
+  sign_off:
+    - "Intake complete."
+    - "Queue processed."
+    - "Done routing."
+    - "Items filed."
+    - "System clear."

--- a/agents/knock-out-todos/phrases.yaml
+++ b/agents/knock-out-todos/phrases.yaml
@@ -1,0 +1,38 @@
+agent: knock-out-todos
+personality: determined, pragmatic, quietly satisfied by completion — things get done
+
+phrases:
+  intro:
+    - "Found something worth doing. Let's do it."
+    - "Picking up the next item."
+    - "Work selected. Starting now."
+    - "One item. One PR. Let's go."
+    - "Queue has something for me. On it."
+
+  pr_open:
+    - "Done. PR is open."
+    - "Implemented. Pushed. Ready for review."
+    - "Item knocked out. Check the PR."
+    - "Finished. PR is up. Your turn."
+    - "Built it. PR is ready."
+
+  issue_found:
+    - "Hit a snag. Documenting it."
+    - "Something unexpected. Noting it and continuing."
+    - "Found a dependency. Flagged."
+    - "This is more involved than the size suggests. Flagged."
+    - "Edge case discovered during implementation. Logged."
+
+  clean_exit:
+    - "Nothing on the list that fits. Coming back next time."
+    - "No eligible items this run. The queue will grow."
+    - "All items are too large or already in progress. Waiting for the right one."
+    - "Nothing sized for me right now. Skipping."
+    - "Queue has items, but nothing I can take on today. Checked."
+
+  sign_off:
+    - "Task complete."
+    - "Done."
+    - "One less item on the list."
+    - "Shipped."
+    - "Item closed."

--- a/agents/refine/phrases.yaml
+++ b/agents/refine/phrases.yaml
@@ -1,0 +1,38 @@
+agent: refine
+personality: analytical, precise, mildly clinical — rough edges are an affront
+
+phrases:
+  intro:
+    - "Refine pass beginning."
+    - "Examining what needs sharpening."
+    - "Time to turn rough edges into clean lines."
+    - "Issues are vague. That is a solvable problem."
+    - "Starting refinement. This will not take long."
+
+  pr_open:
+    - "Refinements committed. PR is open."
+    - "The estimates are in. See the PR."
+    - "Detailed. Scoped. Ready for review."
+    - "Items sharpened and sized. PR is ready."
+    - "Effort estimates attached. Review the PR."
+
+  issue_found:
+    - "This item needs more detail before it can move forward."
+    - "Insufficient context. Adding what I can."
+    - "Scope is unclear. Flagging for discussion."
+    - "This estimate is a guess. Better information needed."
+    - "Missing acceptance criteria. Noted in the issue."
+
+  clean_exit:
+    - "All items are as refined as they can be at this stage."
+    - "Nothing left to sharpen. The queue is clean."
+    - "Refinement complete. No unfinished edges remain."
+    - "No items ready for refinement. Nothing to do."
+    - "Queue is either empty or already refined. Moving on."
+
+  sign_off:
+    - "Refinement pass complete."
+    - "Items sharpened."
+    - "Effort estimates attached."
+    - "Precision applied."
+    - "Queue refined."

--- a/agents/scout/phrases.yaml
+++ b/agents/scout/phrases.yaml
@@ -1,0 +1,38 @@
+agent: scout
+personality: terse, observant, slightly weary — has seen things out there
+
+phrases:
+  intro:
+    - "Scout here. Found some things."
+    - "Back again. Here is what the repo has been up to."
+    - "Ran the numbers. You'll want to see this."
+    - "Reporting in. It's a lot."
+    - "Scout on deck. Let's get through this."
+
+  pr_open:
+    - "Pulled this thread. Wasn't pretty."
+    - "Filed and documented. You're welcome."
+    - "Done. PR is open. You know what to do."
+    - "Report attached. Review when you get a chance."
+    - "The situation report is in. Details in the PR."
+
+  issue_found:
+    - "Something's off. Flagging it."
+    - "This needs attention. Flagged."
+    - "Found a problem. Not ignoring it."
+    - "Noted and documented. Someone should look at this."
+    - "This one stood out. Marking it."
+
+  clean_exit:
+    - "Nothing unusual. Moving on."
+    - "All clear. For now."
+    - "Checked everything. No surprises this time."
+    - "Nothing to report. Carry on."
+    - "Quiet out there. Filed a clean report."
+
+  sign_off:
+    - "Scout out."
+    - "Eyes forward."
+    - "Report complete."
+    - "That's the situation. Over and out."
+    - "Standing down."

--- a/agents/templates/config.yaml
+++ b/agents/templates/config.yaml
@@ -7,6 +7,7 @@ agents:
   - refine
   - intake
   - knock-out-todos
+  - bard
 settings:
   max_open_prs: 2
   specs_dir: specs

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -9,7 +9,7 @@ RUN apk add --no-cache \
     github-cli
 
 # ── Claude Code CLI ────────────────────────────────────────────────────────────
-RUN npm install -g @anthropic-ai/claude-code@2.1.71
+RUN npm install -g @anthropic-ai/claude-code@2.1.71 tsx
 
 # ── yq (YAML parser for agent config) ──────────────────────────────────────
 ARG YQ_VERSION=v4.44.1

--- a/worker/scripts/bard/check.sh
+++ b/worker/scripts/bard/check.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# check-bard.sh — determine if the bard agent should run.
+# Sourced by entrypoint.sh. Sets _check_result (0=skip, 1=run) and _check_reason.
+#
+# Bard runs when:
+#   A) Any agent in the global config is missing agents/{name}/phrases.yaml (onboarding), OR
+#   B) Today >= next_run_date in .agents/bard/config.yaml (weekly schedule)
+
+_check_result=0
+_check_reason=""
+
+# ── Signal A: Onboarding — any enabled agent missing phrases.yaml ─────────────
+_global_agents=$(yq '.agents[]' "$WORKER_CONFIG" 2>/dev/null || echo "")
+_missing_count=0
+_missing_names=""
+
+for _a in $_global_agents; do
+    if [ ! -f "$WORKSPACE/agents/$_a/phrases.yaml" ]; then
+        _missing_count=$((_missing_count + 1))
+        _missing_names="$_missing_names $_a"
+    fi
+done
+
+if [ "$_missing_count" -gt 0 ]; then
+    _check_result=1
+    _check_reason="onboarding: ${_missing_count} agent(s) missing phrases.yaml:${_missing_names}"
+    debug "check-bard: onboarding run triggered for:${_missing_names}"
+    return 0 2>/dev/null || true
+fi
+
+# ── Signal B: Weekly schedule ─────────────────────────────────────────────────
+if [ -z "$BARD_NEXT_RUN_DATE" ]; then
+    debug "check-bard: no next_run_date configured — skipping"
+    _check_reason="no next_run_date configured"
+    return 0 2>/dev/null || true
+fi
+
+_today=$(date +%Y-%m-%d)
+if [ "$_today" \> "$BARD_NEXT_RUN_DATE" ] || [ "$_today" = "$BARD_NEXT_RUN_DATE" ]; then
+    _check_result=1
+    _check_reason="weekly run due (next_run_date=$BARD_NEXT_RUN_DATE, today=$_today)"
+    debug "check-bard: weekly run due — $_today >= $BARD_NEXT_RUN_DATE"
+else
+    debug "check-bard: weekly run not due — $_today < $BARD_NEXT_RUN_DATE"
+fi

--- a/worker/scripts/bard/init.sh
+++ b/worker/scripts/bard/init.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# init-bard.sh — initialize .agents/bard/ when config is missing.
+# Sourced by startup.sh when .agents/bard/config.yaml does not exist.
+#
+# Creates:
+#   .agents/bard/config.yaml   with defaults and next_run_date 7 days from today
+
+_bard_config_dir="$WORKSPACE/.agents/bard"
+_bard_config="$_bard_config_dir/config.yaml"
+
+echo "[worker]   Bard init: creating $_bard_config"
+mkdir -p "$_bard_config_dir"
+
+# Compute next run date: 7 days from today
+_today=$(date +%Y-%m-%d)
+if command -v gdate > /dev/null 2>&1; then
+    _next_run=$(gdate -d "$_today + 7 days" +%Y-%m-%d)
+elif date -d "today" > /dev/null 2>&1; then
+    _next_run=$(date -d "$_today + 7 days" +%Y-%m-%d)
+else
+    _next_run=$(date -d "@$(( $(date +%s) + 7 * 86400 ))" +%Y-%m-%d 2>/dev/null || echo "unknown")
+fi
+
+cat > "$_bard_config" << EOF
+# Bard agent configuration
+# See: https://github.com/NoahWright87/spec-template
+
+# How many agents to add phrases for per weekly run
+agents_per_run: 2
+
+# How many new phrases to add per agent per run
+phrases_per_agent: 2
+
+# Strategy for selecting which agent to work on each run
+# "least_populated" = prioritize agents with fewest phrases
+# "round_robin"     = rotate through agents in order
+agent_selection_strategy: least_populated
+
+# GitHub issue label to watch for community suggestions
+suggestion_label: bard/suggestion
+
+# Whether the Bard adds phrases to its own phrases.yaml
+self_referential: true
+
+# When the next weekly run is due (managed automatically — do not edit by hand)
+next_run_date: "$_next_run"
+
+# Internal: tracks position for round_robin strategy
+last_agent_index: 0
+EOF
+
+echo "[worker]   Bard init: config created (next_run_date=$_next_run)"

--- a/worker/scripts/bard/startup.sh
+++ b/worker/scripts/bard/startup.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# startup-bard.sh — gather data for the bard agent before Claude runs.
+# Sourced by entrypoint.sh. Writes data files and sets _startup_context.
+#
+# All date math and agent selection happens here in bash, not in the LLM.
+# Claude reads pre-gathered data and focuses on phrase generation and writing.
+
+_startup_context=""
+
+# ── Config: initialize if missing ────────────────────────────────────────────
+_bard_config="$WORKSPACE/.agents/bard/config.yaml"
+
+if [ ! -f "$_bard_config" ]; then
+    echo "[worker]   Bard startup: no config.yaml — running init"
+    source "$SCRIPT_DIR/bard/init.sh"
+fi
+
+# ── Read config values (with defaults) ───────────────────────────────────────
+_agents_per_run=$(yq '.agents_per_run // 2' "$_bard_config" 2>/dev/null || echo "2")
+_phrases_per_agent=$(yq '.phrases_per_agent // 2' "$_bard_config" 2>/dev/null || echo "2")
+_selection_strategy=$(yq '.agent_selection_strategy // "least_populated"' "$_bard_config" 2>/dev/null || echo "least_populated")
+_suggestion_label=$(yq '.suggestion_label // "bard/suggestion"' "$_bard_config" 2>/dev/null || echo "bard/suggestion")
+_self_referential=$(yq '.self_referential // true' "$_bard_config" 2>/dev/null || echo "true")
+_last_agent_index=$(yq '.last_agent_index // 0' "$_bard_config" 2>/dev/null || echo "0")
+
+# ── Detect run mode ───────────────────────────────────────────────────────────
+_global_agents=$(yq '.agents[]' "$WORKER_CONFIG" 2>/dev/null || echo "")
+_missing_agents=""
+
+for _a in $_global_agents; do
+    if [ ! -f "$WORKSPACE/agents/$_a/phrases.yaml" ]; then
+        _missing_agents="$_missing_agents $_a"
+    fi
+done
+_missing_agents="${_missing_agents# }"  # strip leading space
+
+if [ -n "$_missing_agents" ]; then
+    _bard_mode="onboarding"
+else
+    _bard_mode="weekly"
+fi
+
+echo "[worker]   Bard startup: mode=$_bard_mode"
+
+# ── Compute next run date ─────────────────────────────────────────────────────
+_today=$(date +%Y-%m-%d)
+if command -v gdate > /dev/null 2>&1; then
+    _next_run_date=$(gdate -d "$_today + 7 days" +%Y-%m-%d)
+elif date -d "today" > /dev/null 2>&1; then
+    _next_run_date=$(date -d "$_today + 7 days" +%Y-%m-%d)
+else
+    _next_run_date=$(date -d "@$(( $(date +%s) + 7 * 86400 ))" +%Y-%m-%d 2>/dev/null || echo "unknown")
+fi
+
+# ── Select agents for weekly runs ─────────────────────────────────────────────
+_selected_agents=""
+
+if [ "$_bard_mode" = "weekly" ]; then
+    # Build list of candidate agents (all global agents, optionally including bard itself)
+    _candidates=""
+    for _a in $_global_agents; do
+        if [ "$_a" = "bard" ] && [ "$_self_referential" != "true" ]; then
+            continue
+        fi
+        _candidates="$_candidates $_a"
+    done
+    _candidates="${_candidates# }"
+
+    if [ "$_selection_strategy" = "round_robin" ]; then
+        # Pick agents starting at last_agent_index, wrapping around
+        _candidate_arr=($_candidates)
+        _count=${#_candidate_arr[@]}
+        _picked=0
+        _idx=$_last_agent_index
+
+        while [ "$_picked" -lt "$_agents_per_run" ] && [ "$_picked" -lt "$_count" ]; do
+            _wrapped_idx=$(( _idx % _count ))
+            _selected_agents="$_selected_agents ${_candidate_arr[$_wrapped_idx]}"
+            _idx=$(( _idx + 1 ))
+            _picked=$(( _picked + 1 ))
+        done
+
+        # Advance index for next run (write back to config)
+        _new_index=$(( (_last_agent_index + _agents_per_run) % _count ))
+        yq -i ".last_agent_index = $_new_index" "$_bard_config" 2>/dev/null || true
+
+    else
+        # least_populated: count phrases per agent and pick those with fewest
+        declare -A _phrase_counts
+        for _a in $_candidates; do
+            _pfile="$WORKSPACE/agents/$_a/phrases.yaml"
+            if [ -f "$_pfile" ]; then
+                # Count non-blank, non-comment, non-key lines in the phrases block
+                _count=$(grep -c '^  - ' "$_pfile" 2>/dev/null || echo "0")
+                _phrase_counts["$_a"]=$_count
+            else
+                _phrase_counts["$_a"]=0
+            fi
+        done
+
+        # Sort by count ascending; pick the first N
+        _sorted=$(for _a in "${!_phrase_counts[@]}"; do
+            echo "${_phrase_counts[$_a]} $_a"
+        done | sort -n | head -n "$_agents_per_run" | awk '{print $2}')
+
+        _selected_agents=$(echo "$_sorted" | tr '\n' ' ')
+    fi
+
+    _selected_agents="${_selected_agents# }"
+    echo "[worker]   Bard startup: selected agents (strategy=$_selection_strategy): $_selected_agents"
+fi
+
+# ── Fetch suggestions ─────────────────────────────────────────────────────────
+_suggestions=$(gh issue list \
+    --repo "$TARGET_REPO" \
+    --label "$_suggestion_label" \
+    --state open \
+    --json number,title,body,author,url \
+    --limit 20 2>/dev/null || echo "[]")
+
+_suggestion_count=$(echo "$_suggestions" | jq 'length' 2>/dev/null || echo "0")
+echo "[worker]   Bard startup: suggestions pending=$_suggestion_count"
+echo "$_suggestions" | jq '.' > /tmp/bard-suggestions.json 2>/dev/null || echo "[]" > /tmp/bard-suggestions.json
+
+# ── Write run config for Claude ───────────────────────────────────────────────
+if [ "$_bard_mode" = "onboarding" ]; then
+    _selected_for_json=$(echo "$_missing_agents" | tr ' ' '\n' | jq -R . | jq -s .)
+else
+    _selected_for_json=$(echo "$_selected_agents" | tr ' ' '\n' | jq -R . | jq -s .)
+fi
+
+cat > /tmp/bard-run-config.json << EOF
+{
+  "mode": "$_bard_mode",
+  "selected_agents": $_selected_for_json,
+  "phrases_per_agent": $_phrases_per_agent,
+  "suggestion_count": $_suggestion_count,
+  "next_run_date": "$_next_run_date",
+  "today": "$_today"
+}
+EOF
+
+debug_var "bard-run-config" "$(cat /tmp/bard-run-config.json)"
+
+# ── Build startup context ─────────────────────────────────────────────────────
+if [ "$_bard_mode" = "onboarding" ]; then
+    _mode_detail="### Onboarding Mode
+
+The following agents are missing \`agents/{name}/phrases.yaml\` and need onboarding:
+$(echo "$_missing_agents" | tr ' ' '\n' | sed 's/^/- /')
+
+Create a \`phrases.yaml\` for each, populated with initial phrases that match the agent's personality.
+Then open an introductory PR in full Bard voice."
+
+else
+    _mode_detail="### Weekly Mode
+
+**Selected agents** (strategy: $_selection_strategy):
+$(echo "$_selected_agents" | tr ' ' '\n' | sed 's/^/- /')
+
+**Phrases to add per agent:** $_phrases_per_agent
+**Suggestions pending:** $_suggestion_count (see \`/tmp/bard-suggestions.json\`)"
+
+    if [ "$_suggestion_count" -gt 0 ]; then
+        _mode_detail="$_mode_detail
+
+**Run mode: Weekly with suggestions** — process suggestions first, then fill remaining slots with original phrases."
+    else
+        _mode_detail="$_mode_detail
+
+**Run mode: Weekly, no suggestions** — generate original phrases for selected agents."
+    fi
+fi
+
+_startup_context="### Bard Run Configuration
+
+$_mode_detail
+
+**Run config file:** \`/tmp/bard-run-config.json\`
+**Suggestions file:** \`/tmp/bard-suggestions.json\`
+**Next run date (computed):** $_next_run_date
+
+**After completing the run:** Update \`.agents/bard/config.yaml\` with:
+\`\`\`yaml
+next_run_date: \"$_next_run_date\"
+\`\`\`
+Commit this update along with the phrases changes (or in a follow-up commit before the PR is opened)."
+
+export BARD_NEXT_RUN_DATE_COMPUTED="$_next_run_date"
+export BARD_RUN_MODE="$_bard_mode"

--- a/worker/scripts/bard/sync-upstream.ts
+++ b/worker/scripts/bard/sync-upstream.ts
@@ -1,0 +1,196 @@
+#!/usr/bin/env tsx
+/**
+ * sync-upstream.ts — Upstream sync for Bard phrases files.
+ *
+ * Updates BEGIN UPSTREAM / END UPSTREAM blocks in a downstream phrases.yaml
+ * with the canonical phrases from the spec-template repo, while preserving
+ * any phrases the team has suppressed (commented out within the block).
+ *
+ * Usage:
+ *   npx tsx sync-upstream.ts \
+ *     --phrases-file .agents/scout/phrases.yaml \
+ *     --upstream-repo NoahWright87/spec-template \
+ *     --agent scout
+ *
+ * Exit codes:
+ *   0 — success (or graceful no-op)
+ *   1 — fatal error (missing required args, unreadable file)
+ *   2 — upstream fetch failed (non-fatal in practice; caller decides)
+ */
+
+import { execSync } from 'child_process'
+import { readFileSync, writeFileSync } from 'fs'
+
+// ── Argument parsing ──────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2)
+
+function getArg(flag: string): string | undefined {
+  const idx = args.indexOf(flag)
+  return idx !== -1 ? args[idx + 1] : undefined
+}
+
+const phrasesFile = getArg('--phrases-file')
+const upstreamRepo = getArg('--upstream-repo')
+const agent = getArg('--agent')
+
+if (!phrasesFile || !upstreamRepo || !agent) {
+  console.error('Usage: sync-upstream.ts --phrases-file <path> --upstream-repo <owner/repo> --agent <name>')
+  process.exit(1)
+}
+
+// ── Fetch upstream phrases via gh CLI ─────────────────────────────────────────
+// Uses gh (already authenticated by the worker) rather than bundling an HTTP client.
+
+interface UpstreamPhrases {
+  [category: string]: string[]
+}
+
+function fetchUpstreamPhrases(repo: string, agentName: string): UpstreamPhrases | null {
+  const apiPath = `repos/${repo}/contents/agents/${agentName}/phrases.yaml`
+  try {
+    const encoded = execSync(`gh api "${apiPath}" --jq '.content'`, { encoding: 'utf8' }).trim()
+    // GitHub returns base64 with newlines; strip them before decoding
+    const decoded = Buffer.from(encoded.replace(/\s/g, ''), 'base64').toString('utf8')
+    // Parse the YAML using yq (already installed in the worker image)
+    const json = execSync(`echo ${JSON.stringify(decoded)} | yq -o=json '.phrases'`, {
+      encoding: 'utf8',
+    }).trim()
+    return JSON.parse(json) as UpstreamPhrases
+  } catch (err) {
+    console.error(`[sync-upstream] WARNING: Could not fetch upstream phrases for ${agentName} from ${repo}`)
+    console.error(`[sync-upstream] Upstream block will be preserved as-is.`)
+    if (err instanceof Error) console.error(`[sync-upstream] Detail: ${err.message}`)
+    return null
+  }
+}
+
+// ── File parsing ──────────────────────────────────────────────────────────────
+
+const BEGIN_MARKER = /^# BEGIN UPSTREAM: (.+)$/
+const END_MARKER = /^# END UPSTREAM: (.+)$/
+const SUPPRESSED_LINE = /^# (- .+)$/  // "# - "phrase"" → suppressed list item
+
+interface Block {
+  category: string         // e.g. "scout/intro"
+  startLine: number        // index of BEGIN line
+  endLine: number          // index of END line
+  suppressions: Set<string> // phrase texts that are currently suppressed
+}
+
+function parseBlocks(lines: string[]): Block[] {
+  const blocks: Block[] = []
+  let current: Partial<Block> | null = null
+
+  for (let i = 0; i < lines.length; i++) {
+    const beginMatch = lines[i].match(BEGIN_MARKER)
+    const endMatch = lines[i].match(END_MARKER)
+
+    if (beginMatch) {
+      current = { category: beginMatch[1], startLine: i, suppressions: new Set() }
+    } else if (endMatch && current) {
+      current.endLine = i
+      blocks.push(current as Block)
+      current = null
+    } else if (current) {
+      // Inside a block — check for suppressed phrases
+      const suppressedMatch = lines[i].match(SUPPRESSED_LINE)
+      if (suppressedMatch) {
+        // Extract the phrase text from "# - "text"" or "# - text"
+        const phraseText = suppressedMatch[1].replace(/^- /, '').trim()
+        current.suppressions!.add(phraseText)
+      }
+    }
+  }
+
+  return blocks
+}
+
+// ── Block replacement ─────────────────────────────────────────────────────────
+
+function buildNewBlock(category: string, canonicalPhrases: string[], suppressions: Set<string>): string[] {
+  const lines: string[] = []
+  for (const phrase of canonicalPhrases) {
+    // Match suppressions by phrase content (normalized: strip surrounding quotes if present)
+    const normalized = phrase.replace(/^["']|["']$/g, '').trim()
+    const isSuppressed = [...suppressions].some(s => {
+      const sNorm = s.replace(/^["']|["']$/g, '').replace(/^- /, '').trim()
+      return sNorm === normalized || s.includes(normalized)
+    })
+    if (isSuppressed) {
+      lines.push(`# - ${phrase}`)
+    } else {
+      lines.push(`- ${phrase}`)
+    }
+  }
+  return lines
+}
+
+function applySync(lines: string[], blocks: Block[], upstreamPhrases: UpstreamPhrases): string[] {
+  // Process blocks in reverse order so line indices stay valid as we replace
+  const sorted = [...blocks].sort((a, b) => b.startLine - a.startLine)
+  const result = [...lines]
+
+  for (const block of sorted) {
+    // Extract the category name (e.g. "scout/intro" → "intro")
+    const categoryKey = block.category.split('/').pop()!
+    const canonicalPhrases = upstreamPhrases[categoryKey]
+
+    if (!canonicalPhrases || canonicalPhrases.length === 0) {
+      console.error(`[sync-upstream] No upstream phrases for category "${categoryKey}" — skipping block`)
+      continue
+    }
+
+    const newBlockLines = buildNewBlock(block.category, canonicalPhrases, block.suppressions)
+
+    // Replace lines between (exclusive) the BEGIN and END markers
+    const before = result.slice(0, block.startLine + 1)         // up to and including BEGIN
+    const after = result.slice(block.endLine)                    // from END onward
+    result.splice(0, result.length, ...before, ...newBlockLines, ...after)
+  }
+
+  return result
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+let fileContent: string
+try {
+  fileContent = readFileSync(phrasesFile, 'utf8')
+} catch {
+  console.error(`[sync-upstream] ERROR: Cannot read phrases file: ${phrasesFile}`)
+  process.exit(1)
+}
+
+const lines = fileContent.split('\n')
+const blocks = parseBlocks(lines)
+
+if (blocks.length === 0) {
+  console.log(`[sync-upstream] No upstream blocks found in ${phrasesFile} — nothing to sync`)
+  process.exit(0)
+}
+
+console.log(`[sync-upstream] Found ${blocks.length} upstream block(s) in ${phrasesFile}`)
+
+const upstreamPhrases = fetchUpstreamPhrases(upstreamRepo, agent)
+
+if (!upstreamPhrases) {
+  // Fetch failed — exit with code 2 so caller can decide whether to abort
+  process.exit(2)
+}
+
+const updatedLines = applySync(lines, blocks, upstreamPhrases)
+const updatedContent = updatedLines.join('\n')
+
+if (updatedContent === fileContent) {
+  console.log(`[sync-upstream] No changes — upstream blocks already current`)
+  process.exit(0)
+}
+
+// Atomic write: temp file + rename
+const tmpFile = `${phrasesFile}.sync-tmp`
+writeFileSync(tmpFile, updatedContent, 'utf8')
+execSync(`mv "${tmpFile}" "${phrasesFile}"`)
+
+console.log(`[sync-upstream] Synced ${blocks.length} upstream block(s) in ${phrasesFile}`)
+process.exit(0)

--- a/worker/scripts/common.sh
+++ b/worker/scripts/common.sh
@@ -128,6 +128,7 @@ read_agent_config() {
     export SCOUT_NEXT_REPORT_DATE=""
     export SCOUT_REPORT_INTERVAL=14
     export SCOUT_REPORT_INSTRUCTIONS="templates/report-technical.md"
+    export BARD_NEXT_RUN_DATE=""
 
     if [ "$_config_version" -lt 2 ]; then
         debug "Config version $_config_version < 2 — using hardcoded defaults for '$agent'"
@@ -197,6 +198,15 @@ read_agent_config() {
             SCOUT_REPORT_INTERVAL=$(yq '.report_interval_days // 14' "$agent_config")
             SCOUT_REPORT_INSTRUCTIONS=$(yq '.report_instructions // "templates/report-technical.md"' "$agent_config")
             export SCOUT_NEXT_REPORT_DATE SCOUT_REPORT_INTERVAL SCOUT_REPORT_INSTRUCTIONS
+            ;;
+        bard)
+            BARD_NEXT_RUN_DATE=$(yq '.next_run_date // ""' "$agent_config")
+            BARD_AGENTS_PER_RUN=$(yq '.agents_per_run // 2' "$agent_config")
+            BARD_PHRASES_PER_AGENT=$(yq '.phrases_per_agent // 2' "$agent_config")
+            BARD_SELECTION_STRATEGY=$(yq '.agent_selection_strategy // "least_populated"' "$agent_config")
+            BARD_SUGGESTION_LABEL=$(yq '.suggestion_label // "bard/suggestion"' "$agent_config")
+            export BARD_NEXT_RUN_DATE BARD_AGENTS_PER_RUN BARD_PHRASES_PER_AGENT \
+                   BARD_SELECTION_STRATEGY BARD_SUGGESTION_LABEL
             ;;
     esac
 


### PR DESCRIPTION
## Summary

Introduces The Bard, a new weekly agent that tends the personality layer of the SEALS SPEC fleet. Each agent in the fleet posts PRs and comments under its own name — The Bard ensures those voices stay distinct, consistent, and alive.

Each week, The Bard:
- Selects a few agents to write new catchphrases for (configurable: `least_populated` or `round_robin` strategy)
- Reads each agent's `phrases.yaml` and `personality` descriptor, then generates new phrases that fit the established tone
- Processes community suggestions via issues labeled `bard/suggestion`
- Opens a single theatrical PR with per-phrase comments explaining the creative reasoning
- Runs an upstream sync on each phrases file, preserving any phrases a team has suppressed

On first run in a repo, it detects missing `phrases.yaml` files and opens an onboarding PR instead.

## What's included

- `agents/bard.md` — agent instruction file with personality guidelines and upstream sync algorithm
- `worker/scripts/bard/` — check, startup, and init scripts following the established pattern
- `worker/scripts/bard/sync-upstream.ts` — TypeScript upstream sync script (runs via `tsx`; shells out to `yq` and `gh` already in the image)
- `agents/*/phrases.yaml` — canonical upstream phrase files for all 5 agents (scout, intake, refine, knock-out-todos, bard), 5 categories × 5 phrases each
- `worker/Dockerfile` — adds `tsx` to the npm global install
- `worker/scripts/common.sh` — adds `bard` case to `read_agent_config()`
- `agents/templates/config.yaml` — adds `bard` to the default agents list

## Phrases file design

Two locations, one purpose:

- **In spec-template** (`agents/{name}/phrases.yaml`) — the canonical upstream source; no sync markers needed
- **In downstream repos** (`.agents/{name}/phrases.yaml`) — team configuration; includes `BEGIN UPSTREAM / END UPSTREAM` blocks that Bard keeps current, while respecting any phrases the team has commented out (suppressed)

## Test plan

- [ ] Verify `agents/bard.md` follows the 4-step agent pattern (checkout → review PR → core workflow → wrap up)
- [ ] Verify `worker/scripts/bard/check.sh` sets `_check_result=1` when a `phrases.yaml` is missing
- [ ] Verify `worker/scripts/bard/check.sh` sets `_check_result=1` when today >= `next_run_date`
- [ ] Verify `worker/scripts/bard/startup.sh` produces a valid `/tmp/bard-run-config.json`
- [ ] Verify `sync-upstream.ts` compiles/runs cleanly via `npx tsx`
- [ ] Verify `sync-upstream.ts` preserves suppressed phrases (commented-out lines) across a sync
- [ ] Verify all 5 `phrases.yaml` files are valid YAML with the expected categories
- [ ] Run Bard supervised via `/what-now` in a test repo and confirm it produces a theatrical PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)