### PR TITLE
feat(scout): enable meta-report aggregating multiple subordinate repos

### DIFF
--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -54,3 +54,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-worker.yml
+++ b/.github/workflows/build-worker.yml
@@ -52,7 +52,6 @@ jobs:
           context: .
           file: worker/Dockerfile
           push: true
+          no-cache: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max

--- a/agents/scout.md
+++ b/agents/scout.md
@@ -27,7 +27,10 @@ If there is no PR in the Situation Report, skip directly to the core workflow.
 
 ### 3. Core workflow
 
-Read and follow [tasks/generate-report.md](tasks/generate-report.md) — gather data and generate the progress report.
+Check the **Situation Report** for `Mode: META-REPORT`.
+
+- **If meta-report mode:** read and follow [tasks/generate-meta-report.md](tasks/generate-meta-report.md) — aggregate data from all repos and generate a combined progress report.
+- **Otherwise:** read and follow [tasks/generate-report.md](tasks/generate-report.md) — gather data and generate the progress report for this repo.
 
 **Important:** Base your analysis on the most recent state of `main`. The startup script fetches the latest changes, but always verify you are working with current data and not stale history.
 

--- a/agents/tasks/generate-meta-report.md
+++ b/agents/tasks/generate-meta-report.md
@@ -1,0 +1,188 @@
+# Generate Meta-Report
+
+## Purpose
+
+Generate a single progress report that aggregates activity across the meta repo and one or more subordinate repos. The report is saved as `{reports_dir}/{date}/data.json` in the [repo-report](https://github.com/NoahWright87/repo-report) `SprintReport` format, with `meta.repos` covering all repos. After generating the report, advance `next_report_date` in `.agents/scout/config.yaml`.
+
+## Preconditions
+
+- `gh` CLI is authenticated and available.
+- The startup script has run and populated:
+  - `/tmp/scout-data/` — meta repo activity data
+  - `/tmp/scout-data/repos/{owner}/{repo}/` — per-subordinate-repo activity data
+
+## Steps
+
+### Step 1 — Read pre-gathered data
+
+Read the **Situation Report** for the report date, reports directory, and list of subordinate repos. Then read all data files:
+
+**Meta repo (`/tmp/scout-data/`):**
+- `git-log.txt` — commit log since baseline
+- `git-stat.txt` — diff stats since baseline
+- `merged-prs.json` — recently merged PRs with descriptions
+- `closed-issues.json` — recently closed issues
+- `open-prs.json` — currently open PRs
+- `open-issues.json` — currently open issues
+
+**Each subordinate repo (`/tmp/scout-data/repos/{owner}/{repo}/`):**
+- Same file structure as the meta repo
+
+### Step 2 — Create output directory
+
+```bash
+mkdir -p {reports_dir}/{date}
+```
+
+### Step 3 — Build the JSON report
+
+Construct a JSON object matching the `SprintReport` schema. Use the template file referenced in `.agents/scout/config.yaml` under `report_instructions` for structure guidance.
+
+#### `meta` object
+
+| Field | Value |
+|-------|-------|
+| `title` | `"Progress Report — {date}"` |
+| `team` | Org or team name (extract org from `TARGET_REPO`, e.g. `"myorg"`) |
+| `dateRange` | `{ "start": "{baseline_date}", "end": "{date}" }` |
+| `repos` | Array with one entry per repo (meta repo first, then subordinates) |
+| `generatedAt` | Current ISO 8601 timestamp |
+
+Build the `repos` array from the Situation Report's repo list. Each entry:
+```json
+{ "name": "{repo-name}", "url": "https://github.com/{owner}/{repo-name}" }
+```
+
+#### `summary` slide
+
+- **`type`**: `"summary"`
+- **`slug`**: `"summary"`
+- **`title`**: `"Summary"`
+- **`stats`**: Aggregate counts across **all** repos:
+  - PRs merged — sum of `merged-prs.json` lengths across all repos
+  - Issues closed — sum of `closed-issues.json` lengths across all repos
+  - Open PRs — sum of `open-prs.json` lengths across all repos
+  - Open `intake:filed` issues — sum of filtered `open-issues.json` across all repos
+- **`highlights`**: Write a 3–5 sentence narrative covering all repos — what shipped, what's active, notable cross-repo patterns.
+- **`detailBlocks`**: One `contributor-list` block aggregating contributors across all repos:
+  - Group merged PRs by `author.login` across all repos to get `prsMerged` per contributor
+  - Count commits per author from all `git-log.txt` files
+  - Include `name`, `username`, `commits`, `prsMerged`
+
+#### `themes` array
+
+Organize themes by repo. For each repo with activity, produce a theme group labeled with the repo name.
+
+**Completed work per repo** — for each repo that has merged PRs, group them by theme and produce theme slides:
+
+```json
+{
+  "type": "theme",
+  "slug": "{repo-slug}-{theme-slug}",
+  "title": "{owner}/{repo} — {Group Name}",
+  "status": "completed",
+  "description": "<one sentence summary of what this group accomplished>",
+  "detailBlocks": [
+    {
+      "type": "link-list",
+      "title": "Merged PRs",
+      "links": [
+        {
+          "label": "<PR title>",
+          "url": "<PR url>",
+          "type": "pr",
+          "description": "<one sentence from PR body — what problem it solved>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Omit the repo prefix in `title` if there is only one repo with activity (keeps the report clean for near-single-repo cases).
+
+**In Progress** — one combined theme for all open PRs across repos:
+
+```json
+{
+  "type": "theme",
+  "slug": "in-progress",
+  "title": "In Progress",
+  "status": "in-progress",
+  "detailBlocks": [
+    {
+      "type": "link-list",
+      "title": "Open PRs",
+      "links": [
+        {
+          "label": "<PR title>",
+          "url": "<PR url>",
+          "type": "pr",
+          "description": "<repo name — branch name or brief status note>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Omit this theme if there are no open PRs across any repo.
+
+**Upcoming** — one combined theme for all `intake:filed` issues across repos:
+
+```json
+{
+  "type": "theme",
+  "slug": "upcoming",
+  "title": "Upcoming",
+  "status": "in-progress",
+  "detailBlocks": [
+    {
+      "type": "link-list",
+      "title": "Filed Issues",
+      "links": [
+        {
+          "label": "<issue title>",
+          "url": "<issue url>",
+          "type": "issue",
+          "description": "<repo name — size label if present>"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Omit this theme if there are no `intake:filed` issues across any repo.
+
+### Step 4 — Write the report
+
+Save the complete JSON object to `{reports_dir}/{date}/data.json`.
+
+Validate that the JSON is well-formed before writing (use the Bash tool to pipe through `jq .` if needed).
+
+### Step 5 — Advance next_report_date
+
+The next report date is shown in the Situation Report. Update `.agents/scout/config.yaml` with the new `next_report_date`.
+
+**IMPORTANT:** Commit the report and the config update in the same commit.
+
+## Preferred tools
+
+- **Read** — read data files from `/tmp/scout-data/` and `/tmp/scout-data/repos/`, report template, config
+- **Write** — create `{reports_dir}/{date}/data.json`
+- **Edit** — update `.agents/scout/config.yaml`
+- **Bash** — `mkdir`, `jq` (for JSON validation), `ls /tmp/scout-data/repos/` (to enumerate subordinate repos)
+
+## Inputs
+
+- `/tmp/scout-data/` — meta repo activity data (git-log.txt, merged-prs.json, etc.)
+- `/tmp/scout-data/repos/{owner}/{repo}/` — per-subordinate-repo activity data (same structure)
+- Situation Report — report date, reports directory, next report date, repo list
+- `.agents/scout/config.yaml` — report template path, reports directory, interval settings
+- `.agents/scout/templates/` — JSON example template (schema reference and guidance)
+
+## Outputs
+
+- `{reports_dir}/{date}/data.json` — the generated meta progress report in SprintReport JSON format
+- `.agents/scout/config.yaml` — updated `next_report_date`

--- a/agents/tasks/generate-meta-report.md
+++ b/agents/tasks/generate-meta-report.md
@@ -2,31 +2,43 @@
 
 ## Purpose
 
-Generate a single progress report that aggregates activity across the meta repo and one or more subordinate repos. The report is saved as `{reports_dir}/{date}/data.json` in the [repo-report](https://github.com/NoahWright87/repo-report) `SprintReport` format, with `meta.repos` covering all repos. After generating the report, advance `next_report_date` in `.agents/scout/config.yaml`.
+Generate a single progress report that aggregates activity across the meta repo and its subordinate repos. The report is saved as `{reports_dir}/{date}/data.json` in the [repo-report](https://github.com/NoahWright87/repo-report) `SprintReport` format. After generating the report, advance `next_report_date` in `.agents/scout/config.yaml`.
+
+The startup script has done all the data-gathering and arithmetic. Your job is synthesis: write narratives, group PRs into themes, and assemble the final JSON.
 
 ## Preconditions
 
-- `gh` CLI is authenticated and available.
 - The startup script has run and populated:
   - `/tmp/scout-data/` — meta repo activity data
   - `/tmp/scout-data/repos/{owner}/{repo}/` — per-subordinate-repo activity data
+  - `/tmp/scout-data/meta-index.json` — pre-built repo index with stats and URLs
+  - `/tmp/scout-data/meta-stats.json` — pre-computed fleet-wide totals
 
 ## Steps
 
-### Step 1 — Read pre-gathered data
+### Step 1 — Read pre-computed data
 
-Read the **Situation Report** for the report date, reports directory, and list of subordinate repos. Then read all data files:
+Read the **Situation Report** for the report date, reports directory, and next report date.
 
-**Meta repo (`/tmp/scout-data/`):**
-- `git-log.txt` — commit log since baseline
-- `git-stat.txt` — diff stats since baseline
-- `merged-prs.json` — recently merged PRs with descriptions
-- `closed-issues.json` — recently closed issues
-- `open-prs.json` — currently open PRs
-- `open-issues.json` — currently open issues
+Then read these pre-computed files (do not re-fetch from GitHub):
 
-**Each subordinate repo (`/tmp/scout-data/repos/{owner}/{repo}/`):**
-- Same file structure as the meta repo
+- `/tmp/scout-data/meta-index.json` — array of repo objects, each with:
+  - `repo` — full `owner/repo` slug
+  - `name` — repo name only
+  - `github_url` — `https://github.com/owner/repo`
+  - `reports_url` — `https://owner.github.io/repo/` (this repo's Scout reports page)
+  - `data_dir` — local path to this repo's data files
+  - `is_meta` — `true` for the meta repo, `false` for subordinates
+  - `prs_merged`, `issues_closed`, `open_prs`, `open_issues`, `intake_filed` — pre-counted
+
+- `/tmp/scout-data/meta-stats.json` — fleet totals:
+  - `total_prs_merged`, `total_issues_closed`, `total_open_prs`, `total_intake_filed`
+
+For each repo in the index, read its `data_dir` files for full detail:
+- `merged-prs.json` — merged PRs with titles, URLs, authors, and body
+- `open-prs.json` — open PRs
+- `open-issues.json` — open issues (filter for `intake:filed` label)
+- `git-log.txt` — commits since baseline (for contributor counts)
 
 ### Step 2 — Create output directory
 
@@ -36,49 +48,40 @@ mkdir -p {reports_dir}/{date}
 
 ### Step 3 — Build the JSON report
 
-Construct a JSON object matching the `SprintReport` schema. Use the template file referenced in `.agents/scout/config.yaml` under `report_instructions` for structure guidance.
+Use the template at `.agents/scout/config.yaml` → `report_instructions` for schema reference.
 
 #### `meta` object
 
 | Field | Value |
 |-------|-------|
 | `title` | `"Progress Report — {date}"` |
-| `team` | Org or team name (extract org from `TARGET_REPO`, e.g. `"myorg"`) |
+| `team` | Org name (the owner portion of `TARGET_REPO`, e.g. `"myorg"`) |
 | `dateRange` | `{ "start": "{baseline_date}", "end": "{date}" }` |
-| `repos` | Array with one entry per repo (meta repo first, then subordinates) |
+| `repos` | One entry per repo from `meta-index.json` — use `reports_url` as `url` for subordinate repos so readers can navigate to their full Scout reports; use `github_url` for the meta repo |
 | `generatedAt` | Current ISO 8601 timestamp |
-
-Build the `repos` array from the Situation Report's repo list. Each entry:
-```json
-{ "name": "{repo-name}", "url": "https://github.com/{owner}/{repo-name}" }
-```
 
 #### `summary` slide
 
-- **`type`**: `"summary"`
-- **`slug`**: `"summary"`
-- **`title`**: `"Summary"`
-- **`stats`**: Aggregate counts across **all** repos:
-  - PRs merged — sum of `merged-prs.json` lengths across all repos
-  - Issues closed — sum of `closed-issues.json` lengths across all repos
-  - Open PRs — sum of `open-prs.json` lengths across all repos
-  - Open `intake:filed` issues — sum of filtered `open-issues.json` across all repos
-- **`highlights`**: Write a 3–5 sentence narrative covering all repos — what shipped, what's active, notable cross-repo patterns.
-- **`detailBlocks`**: One `contributor-list` block aggregating contributors across all repos:
-  - Group merged PRs by `author.login` across all repos to get `prsMerged` per contributor
-  - Count commits per author from all `git-log.txt` files
+- **`stats`**: Use values from `meta-stats.json` directly — no arithmetic needed:
+  - PRs Merged → `total_prs_merged`
+  - Issues Closed → `total_issues_closed`
+  - Open PRs → `total_open_prs`
+  - Filed Issues → `total_intake_filed`
+- **`highlights`**: 3–5 sentence narrative covering all repos — what shipped, what's active, notable cross-repo patterns.
+- **`detailBlocks`**: One `contributor-list` block. Aggregate contributors across all repos:
+  - For each repo, read `merged-prs.json` and count `prsMerged` per `author.login`
+  - For each repo, parse `git-log.txt` lines (`<sha> <message>`) and count commits per author prefix (use the author field from the PR list, not git log, for accuracy — git-log.txt is for volume reference)
+  - Merge counts by `username` across repos
   - Include `name`, `username`, `commits`, `prsMerged`
 
 #### `themes` array
 
-Organize themes by repo. For each repo with activity, produce a theme group labeled with the repo name.
-
-**Completed work per repo** — for each repo that has merged PRs, group them by theme and produce theme slides:
+**Completed work** — for each repo that has merged PRs, read its `merged-prs.json` and group PRs into natural themes. For each theme, produce a slide:
 
 ```json
 {
   "type": "theme",
-  "slug": "{repo-slug}-{theme-slug}",
+  "slug": "{repo-name}-{theme-slug}",
   "title": "{owner}/{repo} — {Group Name}",
   "status": "completed",
   "description": "<one sentence summary of what this group accomplished>",
@@ -94,12 +97,26 @@ Organize themes by repo. For each repo with activity, produce a theme group labe
           "description": "<one sentence from PR body — what problem it solved>"
         }
       ]
+    },
+    {
+      "type": "link-list",
+      "title": "Full Report",
+      "links": [
+        {
+          "label": "See all {owner}/{repo} activity →",
+          "url": "<reports_url from meta-index.json for this repo>",
+          "type": "link",
+          "description": "Detailed Scout report for this repo"
+        }
+      ]
     }
   ]
 }
 ```
 
-Omit the repo prefix in `title` if there is only one repo with activity (keeps the report clean for near-single-repo cases).
+Use the `reports_url` from `meta-index.json` for the "Full Report" link. This lets readers drill into a single repo's Scout reports for more detail.
+
+If only one repo has merged PRs, omit the `{owner}/{repo} —` prefix in the theme title to keep the report clean.
 
 **In Progress** — one combined theme for all open PRs across repos:
 
@@ -118,7 +135,7 @@ Omit the repo prefix in `title` if there is only one repo with activity (keeps t
           "label": "<PR title>",
           "url": "<PR url>",
           "type": "pr",
-          "description": "<repo name — branch name or brief status note>"
+          "description": "<owner/repo — branch name or brief status note>"
         }
       ]
     }
@@ -145,7 +162,7 @@ Omit this theme if there are no open PRs across any repo.
           "label": "<issue title>",
           "url": "<issue url>",
           "type": "issue",
-          "description": "<repo name — size label if present>"
+          "description": "<owner/repo — size label if present, e.g. 'size: M'>"
         }
       ]
     }
@@ -159,30 +176,38 @@ Omit this theme if there are no `intake:filed` issues across any repo.
 
 Save the complete JSON object to `{reports_dir}/{date}/data.json`.
 
-Validate that the JSON is well-formed before writing (use the Bash tool to pipe through `jq .` if needed).
+Validate that the JSON is well-formed before writing:
+```bash
+cat {reports_dir}/{date}/data.json | jq . > /dev/null
+```
 
 ### Step 5 — Advance next_report_date
 
-The next report date is shown in the Situation Report. Update `.agents/scout/config.yaml` with the new `next_report_date`.
+The next report date is in the Situation Report. Update `.agents/scout/config.yaml`:
+
+```yaml
+next_report_date: "{next_report_date}"
+```
 
 **IMPORTANT:** Commit the report and the config update in the same commit.
 
 ## Preferred tools
 
-- **Read** — read data files from `/tmp/scout-data/` and `/tmp/scout-data/repos/`, report template, config
+- **Read** — read `meta-index.json`, `meta-stats.json`, per-repo data files, template, config
 - **Write** — create `{reports_dir}/{date}/data.json`
 - **Edit** — update `.agents/scout/config.yaml`
-- **Bash** — `mkdir`, `jq` (for JSON validation), `ls /tmp/scout-data/repos/` (to enumerate subordinate repos)
+- **Bash** — `mkdir`, `jq .` (validation only)
 
 ## Inputs
 
-- `/tmp/scout-data/` — meta repo activity data (git-log.txt, merged-prs.json, etc.)
-- `/tmp/scout-data/repos/{owner}/{repo}/` — per-subordinate-repo activity data (same structure)
-- Situation Report — report date, reports directory, next report date, repo list
-- `.agents/scout/config.yaml` — report template path, reports directory, interval settings
-- `.agents/scout/templates/` — JSON example template (schema reference and guidance)
+- `/tmp/scout-data/meta-index.json` — pre-built repo index with stats and URLs
+- `/tmp/scout-data/meta-stats.json` — pre-computed fleet-wide totals
+- `/tmp/scout-data/` and `/tmp/scout-data/repos/{owner}/{repo}/` — per-repo activity files
+- Situation Report — report date, reports directory, next report date
+- `.agents/scout/config.yaml` — report template path, reports directory
+- `.agents/scout/templates/` — JSON example template (schema reference)
 
 ## Outputs
 
-- `{reports_dir}/{date}/data.json` — the generated meta progress report in SprintReport JSON format
+- `{reports_dir}/{date}/data.json` — meta progress report in SprintReport JSON format
 - `.agents/scout/config.yaml` — updated `next_report_date`

--- a/agents/tasks/generate-meta-report.md
+++ b/agents/tasks/generate-meta-report.md
@@ -2,43 +2,31 @@
 
 ## Purpose
 
-Generate a single progress report that aggregates activity across the meta repo and its subordinate repos. The report is saved as `{reports_dir}/{date}/data.json` in the [repo-report](https://github.com/NoahWright87/repo-report) `SprintReport` format. After generating the report, advance `next_report_date` in `.agents/scout/config.yaml`.
+Generate a combined progress report for the meta repo and its sub-scouts. The report covers:
+1. The meta repo's own activity (from raw data in `/tmp/scout-data/`, same as a normal Scout run)
+2. A summary section per sub-scout, drawn from each sub-scout's already-generated `data.json`
 
-The startup script has done all the data-gathering and arithmetic. Your job is synthesis: write narratives, group PRs into themes, and assemble the final JSON.
+The output is saved as `{reports_dir}/{date}/data.json` in the [repo-report](https://github.com/NoahWright87/repo-report) `SprintReport` format. After generating the report, advance `next_report_date` in `.agents/scout/config.yaml`.
 
 ## Preconditions
 
 - The startup script has run and populated:
-  - `/tmp/scout-data/` — meta repo activity data
-  - `/tmp/scout-data/repos/{owner}/{repo}/` — per-subordinate-repo activity data
-  - `/tmp/scout-data/meta-index.json` — pre-built repo index with stats and URLs
-  - `/tmp/scout-data/meta-stats.json` — pre-computed fleet-wide totals
+  - `/tmp/scout-data/` — meta repo activity (same files as a normal Scout run)
+  - `/tmp/scout-data/meta-index.json` — repo index with stats, URLs, and `has_report` flags
+  - `/tmp/scout-data/meta-stats.json` — fleet-wide aggregate totals
+  - `/tmp/scout-data/subordinates/{owner}/{repo}/latest-report.json` — fetched sub-scout reports (when `has_report: true`)
 
 ## Steps
 
 ### Step 1 — Read pre-computed data
 
-Read the **Situation Report** for the report date, reports directory, and next report date.
+Read the **Situation Report** for the report date, reports directory, next report date, and the list of sub-scouts (including which have reports and which don't).
 
-Then read these pre-computed files (do not re-fetch from GitHub):
-
-- `/tmp/scout-data/meta-index.json` — array of repo objects, each with:
-  - `repo` — full `owner/repo` slug
-  - `name` — repo name only
-  - `github_url` — `https://github.com/owner/repo`
-  - `reports_url` — `https://owner.github.io/repo/` (this repo's Scout reports page)
-  - `data_dir` — local path to this repo's data files
-  - `is_meta` — `true` for the meta repo, `false` for subordinates
-  - `prs_merged`, `issues_closed`, `open_prs`, `open_issues`, `intake_filed` — pre-counted
-
-- `/tmp/scout-data/meta-stats.json` — fleet totals:
-  - `total_prs_merged`, `total_issues_closed`, `total_open_prs`, `total_intake_filed`
-
-For each repo in the index, read its `data_dir` files for full detail:
-- `merged-prs.json` — merged PRs with titles, URLs, authors, and body
-- `open-prs.json` — open PRs
-- `open-issues.json` — open issues (filter for `intake:filed` label)
-- `git-log.txt` — commits since baseline (for contributor counts)
+Read:
+- `/tmp/scout-data/meta-index.json` — index of all repos
+- `/tmp/scout-data/meta-stats.json` — aggregate totals
+- `/tmp/scout-data/merged-prs.json`, `closed-issues.json`, `open-prs.json`, `open-issues.json`, `git-log.txt` — meta repo raw data
+- For each sub-scout where `has_report: true`: read its `report_file` (the fetched `data.json`)
 
 ### Step 2 — Create output directory
 
@@ -55,47 +43,52 @@ Use the template at `.agents/scout/config.yaml` → `report_instructions` for sc
 | Field | Value |
 |-------|-------|
 | `title` | `"Progress Report — {date}"` |
-| `team` | Org name (the owner portion of `TARGET_REPO`, e.g. `"myorg"`) |
+| `team` | Org name (owner portion of `TARGET_REPO`) |
 | `dateRange` | `{ "start": "{baseline_date}", "end": "{date}" }` |
-| `repos` | One entry per repo from `meta-index.json` — use `reports_url` as `url` for subordinate repos so readers can navigate to their full Scout reports; use `github_url` for the meta repo |
+| `repos` | One entry per repo from `meta-index.json`; use `reports_url` as `url` for sub-scouts, `github_url` for the meta repo |
 | `generatedAt` | Current ISO 8601 timestamp |
 
 #### `summary` slide
 
-- **`stats`**: Use values from `meta-stats.json` directly — no arithmetic needed:
-  - PRs Merged → `total_prs_merged`
-  - Issues Closed → `total_issues_closed`
-  - Open PRs → `total_open_prs`
-  - Filed Issues → `total_intake_filed`
-- **`highlights`**: 3–5 sentence narrative covering all repos — what shipped, what's active, notable cross-repo patterns.
-- **`detailBlocks`**: One `contributor-list` block. Aggregate contributors across all repos:
-  - For each repo, read `merged-prs.json` and count `prsMerged` per `author.login`
-  - For each repo, parse `git-log.txt` lines (`<sha> <message>`) and count commits per author prefix (use the author field from the PR list, not git log, for accuracy — git-log.txt is for volume reference)
-  - Merge counts by `username` across repos
-  - Include `name`, `username`, `commits`, `prsMerged`
+- **`stats`**: Use values from `meta-stats.json` directly — `total_prs_merged`, `total_issues_closed`, `total_open_prs`, `total_intake_filed` (only counts repos where `has_report: true`)
+- **`highlights`**: 3–5 sentence narrative covering the meta repo's own activity and any notable patterns across sub-scouts
+- **`detailBlocks`**: One `contributor-list` block from the meta repo's own `merged-prs.json` and `git-log.txt` (same logic as `generate-report.md`)
 
-#### `themes` array
+#### `themes` array — meta repo own activity
 
-**Completed work** — for each repo that has merged PRs, read its `merged-prs.json` and group PRs into natural themes. For each theme, produce a slide:
+Follow the same grouping logic as `generate-report.md` for the meta repo's own data:
+
+- Completed work — group `merged-prs.json` entries into named themes; each theme slug prefixed `meta-` (e.g. `meta-auth-improvements`)
+- In Progress — open PRs from `open-prs.json` (omit if none)
+- Upcoming — `intake:filed` issues from `open-issues.json` (omit if none)
+
+#### `themes` array — sub-scout summaries
+
+For each sub-scout in `meta-index.json`, append one theme slide:
+
+**Sub-scout with `has_report: true`** — read its `report_file` and extract:
+- `summary.highlights` for the description
+- Up to 3 top themes (by number of PRs) for detail
 
 ```json
 {
   "type": "theme",
-  "slug": "{repo-name}-{theme-slug}",
-  "title": "{owner}/{repo} — {Group Name}",
+  "slug": "{sub-name}-summary",
+  "title": "{owner}/{repo}",
   "status": "completed",
-  "description": "<one sentence summary of what this group accomplished>",
+  "description": "<first sentence of sub-scout's summary.highlights>",
   "detailBlocks": [
     {
       "type": "link-list",
-      "title": "Merged PRs",
+      "title": "Highlights",
       "links": [
         {
-          "label": "<PR title>",
-          "url": "<PR url>",
-          "type": "pr",
-          "description": "<one sentence from PR body — what problem it solved>"
+          "label": "<theme title from sub-scout report>",
+          "url": "<reports_url from meta-index>",
+          "type": "link",
+          "description": "<theme description from sub-scout report>"
         }
+        // repeat for up to 3 themes
       ]
     },
     {
@@ -103,10 +96,10 @@ Use the template at `.agents/scout/config.yaml` → `report_instructions` for sc
       "title": "Full Report",
       "links": [
         {
-          "label": "See all {owner}/{repo} activity →",
-          "url": "<reports_url from meta-index.json for this repo>",
+          "label": "See full {owner}/{repo} Scout report →",
+          "url": "<reports_url from meta-index>",
           "type": "link",
-          "description": "Detailed Scout report for this repo"
+          "description": "Report from {report_date}"
         }
       ]
     }
@@ -114,100 +107,61 @@ Use the template at `.agents/scout/config.yaml` → `report_instructions` for sc
 }
 ```
 
-Use the `reports_url` from `meta-index.json` for the "Full Report" link. This lets readers drill into a single repo's Scout reports for more detail.
-
-If only one repo has merged PRs, omit the `{owner}/{repo} —` prefix in the theme title to keep the report clean.
-
-**In Progress** — one combined theme for all open PRs across repos:
+**Sub-scout with `has_report: false`** — include a placeholder theme:
 
 ```json
 {
   "type": "theme",
-  "slug": "in-progress",
-  "title": "In Progress",
+  "slug": "{sub-name}-pending",
+  "title": "{owner}/{repo} — Report Pending",
   "status": "in-progress",
-  "detailBlocks": [
-    {
-      "type": "link-list",
-      "title": "Open PRs",
-      "links": [
-        {
-          "label": "<PR title>",
-          "url": "<PR url>",
-          "type": "pr",
-          "description": "<owner/repo — branch name or brief status note>"
-        }
-      ]
-    }
-  ]
+  "description": "Scout report has not run yet for this repo. Will be included in the next report cycle.",
+  "detailBlocks": []
 }
 ```
 
-Omit this theme if there are no open PRs across any repo.
+### Step 4 — Handle missing sub-scouts (PR comment)
 
-**Upcoming** — one combined theme for all `intake:filed` issues across repos:
+If **any** sub-scouts have `has_report: false`:
 
-```json
-{
-  "type": "theme",
-  "slug": "upcoming",
-  "title": "Upcoming",
-  "status": "in-progress",
-  "detailBlocks": [
-    {
-      "type": "link-list",
-      "title": "Filed Issues",
-      "links": [
-        {
-          "label": "<issue title>",
-          "url": "<issue url>",
-          "type": "issue",
-          "description": "<owner/repo — size label if present, e.g. 'size: M'>"
-        }
-      ]
-    }
-  ]
-}
-```
+After writing the report file, post a comment on the PR noting which sub-scout reports are not yet available:
 
-Omit this theme if there are no `intake:filed` issues across any repo.
-
-### Step 4 — Write the report
-
-Save the complete JSON object to `{reports_dir}/{date}/data.json`.
-
-Validate that the JSON is well-formed before writing:
 ```bash
-cat {reports_dir}/{date}/data.json | jq . > /dev/null
+gh pr comment "$WORKER_PR_NUMBER" --body "🤖 Claude ($AGENT_NAME): The following sub-scout reports were not available for this cycle and will be included once their Scout has run: <list repos>. This report will be updated automatically on the next scheduled run."
 ```
 
-### Step 5 — Advance next_report_date
+### Step 5 — Write the report
 
-The next report date is in the Situation Report. Update `.agents/scout/config.yaml`:
+Save the complete JSON to `{reports_dir}/{date}/data.json` and validate:
 
-```yaml
-next_report_date: "{next_report_date}"
+```bash
+jq . {reports_dir}/{date}/data.json > /dev/null
 ```
 
-**IMPORTANT:** Commit the report and the config update in the same commit.
+### Step 6 — Advance next_report_date
+
+Update `.agents/scout/config.yaml` with the new `next_report_date` from the Situation Report.
+
+**IMPORTANT:** Commit the report and config update in the same commit.
 
 ## Preferred tools
 
-- **Read** — read `meta-index.json`, `meta-stats.json`, per-repo data files, template, config
-- **Write** — create `{reports_dir}/{date}/data.json`
-- **Edit** — update `.agents/scout/config.yaml`
-- **Bash** — `mkdir`, `jq .` (validation only)
+- **Read** — `meta-index.json`, `meta-stats.json`, sub-scout `report_file` paths, meta repo data files, template, config
+- **Write** — `{reports_dir}/{date}/data.json`
+- **Edit** — `.agents/scout/config.yaml`
+- **Bash** — `mkdir`, `jq .` (validation), `gh pr comment` (missing sub-scout notice)
 
 ## Inputs
 
-- `/tmp/scout-data/meta-index.json` — pre-built repo index with stats and URLs
-- `/tmp/scout-data/meta-stats.json` — pre-computed fleet-wide totals
-- `/tmp/scout-data/` and `/tmp/scout-data/repos/{owner}/{repo}/` — per-repo activity files
-- Situation Report — report date, reports directory, next report date
-- `.agents/scout/config.yaml` — report template path, reports directory
-- `.agents/scout/templates/` — JSON example template (schema reference)
+- `/tmp/scout-data/meta-index.json` — repo index with `has_report`, `report_file`, stats, URLs
+- `/tmp/scout-data/meta-stats.json` — pre-computed fleet totals
+- `/tmp/scout-data/` — meta repo raw activity data
+- Sub-scout `report_file` paths (from `meta-index.json`) — already-processed SprintReport JSON
+- Situation Report — report date, reports directory, next report date, missing sub-scouts list
+- `.agents/scout/config.yaml` — template path, reports directory
 
 ## Outputs
 
-- `{reports_dir}/{date}/data.json` — meta progress report in SprintReport JSON format
+- `{reports_dir}/{date}/data.json` — combined SprintReport
 - `.agents/scout/config.yaml` — updated `next_report_date`
+- PR comment (when sub-scouts are missing)

--- a/worker/scripts/common.sh
+++ b/worker/scripts/common.sh
@@ -196,8 +196,11 @@ read_agent_config() {
             SCOUT_NEXT_REPORT_DATE=$(yq '.next_report_date // ""' "$agent_config")
             SCOUT_REPORT_INTERVAL=$(yq '.report_interval_days // 14' "$agent_config")
             SCOUT_REPORT_INSTRUCTIONS=$(yq '.report_instructions // "templates/report-technical.md"' "$agent_config")
-            SCOUT_SUBORDINATE_REPOS=$(yq '.subordinate_repos // [] | join(" ")' "$agent_config" 2>/dev/null || echo "")
-            export SCOUT_NEXT_REPORT_DATE SCOUT_REPORT_INTERVAL SCOUT_REPORT_INSTRUCTIONS SCOUT_SUBORDINATE_REPOS
+            # sub_scouts entries are either a plain "owner/repo" string or an object
+            # {repo: "owner/repo", scout_dir: ".agents/scout"}. Normalize to "repo|dir" pairs.
+            SCOUT_SUB_SCOUTS=$(yq '.sub_scouts // [] | .[] | ((.repo // .) + "|" + (.scout_dir // ".agents/scout"))' \
+                "$agent_config" 2>/dev/null | tr '\n' ' ' | sed 's/[[:space:]]*$//' || echo "")
+            export SCOUT_NEXT_REPORT_DATE SCOUT_REPORT_INTERVAL SCOUT_REPORT_INSTRUCTIONS SCOUT_SUB_SCOUTS
             ;;
     esac
 

--- a/worker/scripts/common.sh
+++ b/worker/scripts/common.sh
@@ -196,7 +196,8 @@ read_agent_config() {
             SCOUT_NEXT_REPORT_DATE=$(yq '.next_report_date // ""' "$agent_config")
             SCOUT_REPORT_INTERVAL=$(yq '.report_interval_days // 14' "$agent_config")
             SCOUT_REPORT_INSTRUCTIONS=$(yq '.report_instructions // "templates/report-technical.md"' "$agent_config")
-            export SCOUT_NEXT_REPORT_DATE SCOUT_REPORT_INTERVAL SCOUT_REPORT_INSTRUCTIONS
+            SCOUT_SUBORDINATE_REPOS=$(yq '.subordinate_repos // [] | join(" ")' "$agent_config" 2>/dev/null || echo "")
+            export SCOUT_NEXT_REPORT_DATE SCOUT_REPORT_INTERVAL SCOUT_REPORT_INSTRUCTIONS SCOUT_SUBORDINATE_REPOS
             ;;
     esac
 

--- a/worker/scripts/scout/init.sh
+++ b/worker/scripts/scout/init.sh
@@ -28,12 +28,15 @@ next_report_date: "${_init_next_date}"
 report_interval_days: 14
 report_instructions: templates/report-technical.md
 reports_dir: docs/reports
-# subordinate_repos: []  # Uncomment and list repos to generate a meta-report that
-#   aggregates activity across multiple repos. Each entry is "owner/repo" format.
+# sub_scouts: []  # List Scout-enabled repos whose reports this Scout should summarize.
+#   Each entry is either a plain "owner/repo" string (scout_dir defaults to .agents/scout/)
+#   or an object with an optional scout_dir override.
 #   Example:
-#     subordinate_repos:
+#     sub_scouts:
 #       - myorg/backend
 #       - myorg/frontend
+#       - repo: myorg/platform
+#         scout_dir: .agents/scout
 EOF
     echo "[worker]   Scout init: wrote config.yaml"
 fi

--- a/worker/scripts/scout/init.sh
+++ b/worker/scripts/scout/init.sh
@@ -29,7 +29,7 @@ report_interval_days: 14
 report_instructions: templates/report-technical.md
 reports_dir: docs/reports
 # sub_scouts: []  # List Scout-enabled repos whose reports this Scout should summarize.
-#   Each entry is either a plain "owner/repo" string (scout_dir defaults to .agents/scout/)
+#   Each entry is either a plain "owner/repo" string (scout_dir defaults to .agents/scout)
 #   or an object with an optional scout_dir override.
 #   Example:
 #     sub_scouts:

--- a/worker/scripts/scout/init.sh
+++ b/worker/scripts/scout/init.sh
@@ -28,6 +28,12 @@ next_report_date: "${_init_next_date}"
 report_interval_days: 14
 report_instructions: templates/report-technical.md
 reports_dir: docs/reports
+# subordinate_repos: []  # Uncomment and list repos to generate a meta-report that
+#   aggregates activity across multiple repos. Each entry is "owner/repo" format.
+#   Example:
+#     subordinate_repos:
+#       - myorg/backend
+#       - myorg/frontend
 EOF
     echo "[worker]   Scout init: wrote config.yaml"
 fi

--- a/worker/scripts/scout/startup.sh
+++ b/worker/scripts/scout/startup.sh
@@ -216,6 +216,7 @@ if [ -n "${SCOUT_SUB_SCOUTS:-}" ]; then
     for _entry in $SCOUT_SUB_SCOUTS; do
         _sub_repo=$(echo "$_entry" | cut -d'|' -f1)
         _sub_scout_dir=$(echo "$_entry" | cut -d'|' -f2)
+        _sub_scout_dir="${_sub_scout_dir%/}"   # strip any trailing slash
         _sub_owner=$(echo "$_sub_repo" | cut -d/ -f1)
         _sub_name=$(echo "$_sub_repo" | cut -d/ -f2)
         _sub_dir="/tmp/scout-data/subordinates/$_sub_owner/$_sub_name"
@@ -254,10 +255,10 @@ if [ -n "${SCOUT_SUB_SCOUTS:-}" ]; then
                     _has_report=true
                     _report_date="$_latest_date"
                     # Extract stats from the child's SprintReport summary
-                    _sub_merged=$(jq '.summary.stats[] | select(.label=="PRs Merged")    | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
-                    _sub_closed=$(jq '.summary.stats[] | select(.label=="Issues Closed") | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
-                    _sub_open_prs=$(jq '.summary.stats[] | select(.label=="Open PRs")    | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
-                    _sub_intake=$(jq '.summary.stats[] | select(.label=="Filed Issues")  | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_merged=$(jq -r 'first(.summary.stats[]? | select(.label=="PRs Merged")    | (.value | tonumber? // 0)) // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_closed=$(jq -r 'first(.summary.stats[]? | select(.label=="Issues Closed") | (.value | tonumber? // 0)) // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_open_prs=$(jq -r 'first(.summary.stats[]? | select(.label=="Open PRs")    | (.value | tonumber? // 0)) // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_intake=$(jq -r 'first(.summary.stats[]? | select(.label=="Filed Issues")  | (.value | tonumber? // 0)) // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
                     echo "[worker]       report from $_report_date — merged=$_sub_merged closed=$_sub_closed open_prs=$_sub_open_prs intake=$_sub_intake"
                 fi
             fi
@@ -275,7 +276,7 @@ if [ -n "${SCOUT_SUB_SCOUTS:-}" ]; then
             --arg  reports_url "https://$_sub_owner.github.io/$_sub_name/" \
             --arg  data_dir    "$_sub_dir" \
             --arg  report_date "${_report_date:-}" \
-            --arg  report_file "${_sub_dir}/latest-report.json" \
+            --arg  report_file "$([ "$_has_report" = true ] && echo "${_sub_dir}/latest-report.json" || echo "")" \
             --argjson has_report    "$_has_report" \
             --argjson prs_merged    "$_sub_merged" \
             --argjson issues_closed "$_sub_closed" \

--- a/worker/scripts/scout/startup.sh
+++ b/worker/scripts/scout/startup.sh
@@ -173,6 +173,63 @@ echo "$_closed_issues" | jq '.' > /tmp/scout-data/closed-issues.json
 echo "$_open_prs" | jq '.' > /tmp/scout-data/open-prs.json
 echo "$_open_issues" | jq '.' > /tmp/scout-data/open-issues.json
 
+# ── Gather subordinate repo data (meta-report mode) ──────────────────────────
+# When SCOUT_SUBORDINATE_REPOS is set, fetch the same data for each subordinate
+# repo using the GitHub API and write per-repo files to /tmp/scout-data/repos/.
+_is_meta_report=false
+_sub_repo_summary=""
+if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
+    _is_meta_report=true
+    echo "[worker]   Meta-report mode: gathering data for subordinate repos..."
+    mkdir -p /tmp/scout-data/repos
+
+    for _sub_repo in $SCOUT_SUBORDINATE_REPOS; do
+        _sub_owner=$(echo "$_sub_repo" | cut -d/ -f1)
+        _sub_name=$(echo "$_sub_repo" | cut -d/ -f2)
+        _sub_dir="/tmp/scout-data/repos/$_sub_owner/$_sub_name"
+        mkdir -p "$_sub_dir"
+
+        echo "[worker]     Fetching: $_sub_repo"
+
+        # Commits via GitHub API (since baseline date)
+        gh api --paginate \
+            "repos/$_sub_repo/commits?since=${_baseline_date}T00:00:00Z&per_page=100" \
+            --jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"' \
+            2>/dev/null > "$_sub_dir/git-log.txt" || echo "(no commits)" > "$_sub_dir/git-log.txt"
+
+        # Merged PRs
+        gh pr list --repo "$_sub_repo" --state merged \
+            --json number,title,mergedAt,author,body,url --limit 200 2>/dev/null \
+            | jq '.' > "$_sub_dir/merged-prs.json" || echo "[]" > "$_sub_dir/merged-prs.json"
+
+        # Closed issues
+        gh issue list --repo "$_sub_repo" --state closed \
+            --json number,title,closedAt,labels,url --limit 200 2>/dev/null \
+            | jq '.' > "$_sub_dir/closed-issues.json" || echo "[]" > "$_sub_dir/closed-issues.json"
+
+        # Open PRs
+        gh pr list --repo "$_sub_repo" --state open \
+            --json number,title,labels,headRefName,url 2>/dev/null \
+            | jq '.' > "$_sub_dir/open-prs.json" || echo "[]" > "$_sub_dir/open-prs.json"
+
+        # Open issues
+        gh issue list --repo "$_sub_repo" --state open \
+            --json number,title,labels,url 2>/dev/null \
+            | jq '.' > "$_sub_dir/open-issues.json" || echo "[]" > "$_sub_dir/open-issues.json"
+
+        _sub_merged=$(jq 'length' "$_sub_dir/merged-prs.json" 2>/dev/null || echo "0")
+        _sub_closed=$(jq 'length' "$_sub_dir/closed-issues.json" 2>/dev/null || echo "0")
+        _sub_open_prs=$(jq 'length' "$_sub_dir/open-prs.json" 2>/dev/null || echo "0")
+        _sub_intake=$(jq '[.[] | select(.labels[]?.name == "intake:filed")] | length' \
+            "$_sub_dir/open-issues.json" 2>/dev/null || echo "0")
+
+        echo "[worker]     $_sub_repo: merged_prs=$_sub_merged closed_issues=$_sub_closed open_prs=$_sub_open_prs intake:filed=$_sub_intake"
+
+        _sub_repo_summary="${_sub_repo_summary}
+- \`$_sub_repo\`: ${_sub_merged} PRs merged, ${_sub_closed} issues closed, ${_sub_open_prs} open PRs, ${_sub_intake} filed — data: \`$_sub_dir/\`"
+    done
+fi
+
 # ── Build startup context for situation report ───────────────────────────────
 _startup_context="### Report Data (pre-gathered by startup script)
 
@@ -184,7 +241,7 @@ do not re-fetch from GitHub or git.
 **Reports directory:** \`${SCOUT_REPORTS_DIR}\`
 **Next report date (computed):** ${_next_report_date}
 
-**Summary metrics:**
+**Summary metrics (${TARGET_REPO}):**
 - PRs merged: ${_merged_prs_count}
 - Issues closed: ${_closed_issues_count}
 - Open PRs: $(echo "$_open_prs" | jq 'length' 2>/dev/null || echo "0")
@@ -202,6 +259,20 @@ do not re-fetch from GitHub or git.
 **Date advancement:** After generating the report, update \`.agents/scout/config.yaml\`
 with \`next_report_date: \"${_next_report_date}\"\`. Commit both the report and the
 config update in the same commit."
+
+# Append meta-report section when subordinate repos are configured
+if [ "$_is_meta_report" = true ]; then
+    _startup_context="${_startup_context}
+
+### Meta-Report Mode
+
+**Mode: META-REPORT** — Follow \`/worker/agents/tasks/generate-meta-report.md\` instead of \`generate-report.md\`.
+
+**Subordinate repos (data pre-gathered):**${_sub_repo_summary}
+
+Each subordinate repo's data directory contains the same files as the meta repo:
+\`git-log.txt\`, \`merged-prs.json\`, \`closed-issues.json\`, \`open-prs.json\`, \`open-issues.json\`."
+fi
 
 # Export for use by the agent
 export SCOUT_REPORT_DATE="$_today"

--- a/worker/scripts/scout/startup.sh
+++ b/worker/scripts/scout/startup.sh
@@ -174,15 +174,44 @@ echo "$_open_prs" | jq '.' > /tmp/scout-data/open-prs.json
 echo "$_open_issues" | jq '.' > /tmp/scout-data/open-issues.json
 
 # ── Gather subordinate repo data (meta-report mode) ──────────────────────────
-# When SCOUT_SUBORDINATE_REPOS is set, fetch the same data for each subordinate
-# repo using the GitHub API and write per-repo files to /tmp/scout-data/repos/.
+# When SCOUT_SUBORDINATE_REPOS is set, fetch data for each subordinate repo
+# using the GitHub API, then pre-compute aggregate stats and a repo index so
+# Claude only needs to synthesize narratives and group themes — no arithmetic.
 _is_meta_report=false
 _sub_repo_summary=""
+
 if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
     _is_meta_report=true
     echo "[worker]   Meta-report mode: gathering data for subordinate repos..."
     mkdir -p /tmp/scout-data/repos
 
+    # ── Seed meta-index with the meta repo entry ─────────────────────────
+    _meta_owner=$(echo "$TARGET_REPO" | cut -d/ -f1)
+    _meta_name=$(echo "$TARGET_REPO" | cut -d/ -f2)
+    _meta_open_prs_count=$(echo "$_open_prs" | jq 'length' 2>/dev/null || echo "0")
+
+    _index_entries=$(jq -n \
+        --arg  repo         "$TARGET_REPO" \
+        --arg  name         "$_meta_name" \
+        --arg  github_url   "https://github.com/$TARGET_REPO" \
+        --arg  reports_url  "https://$_meta_owner.github.io/$_meta_name/" \
+        --arg  data_dir     "/tmp/scout-data" \
+        --argjson prs_merged    "$_merged_prs_count" \
+        --argjson issues_closed "$_closed_issues_count" \
+        --argjson open_prs      "$_meta_open_prs_count" \
+        --argjson open_issues   "$_new_issues_count" \
+        --argjson intake_filed  "$_intake_count" \
+        '[{repo:$repo,name:$name,github_url:$github_url,reports_url:$reports_url,
+           data_dir:$data_dir,is_meta:true,prs_merged:$prs_merged,
+           issues_closed:$issues_closed,open_prs:$open_prs,
+           open_issues:$open_issues,intake_filed:$intake_filed}]')
+
+    _total_merged=$_merged_prs_count
+    _total_closed=$_closed_issues_count
+    _total_open_prs=$_meta_open_prs_count
+    _total_intake=$_intake_count
+
+    # ── Fetch each subordinate repo and append to index ───────────────────
     for _sub_repo in $SCOUT_SUBORDINATE_REPOS; do
         _sub_owner=$(echo "$_sub_repo" | cut -d/ -f1)
         _sub_name=$(echo "$_sub_repo" | cut -d/ -f2)
@@ -195,39 +224,81 @@ if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
         gh api --paginate \
             "repos/$_sub_repo/commits?since=${_baseline_date}T00:00:00Z&per_page=100" \
             --jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"' \
-            2>/dev/null > "$_sub_dir/git-log.txt" || echo "(no commits)" > "$_sub_dir/git-log.txt"
+            2>/dev/null > "$_sub_dir/git-log.txt" \
+            || echo "(no commits)" > "$_sub_dir/git-log.txt"
 
         # Merged PRs
         gh pr list --repo "$_sub_repo" --state merged \
             --json number,title,mergedAt,author,body,url --limit 200 2>/dev/null \
-            | jq '.' > "$_sub_dir/merged-prs.json" || echo "[]" > "$_sub_dir/merged-prs.json"
+            | jq '.' > "$_sub_dir/merged-prs.json" \
+            || echo "[]" > "$_sub_dir/merged-prs.json"
 
         # Closed issues
         gh issue list --repo "$_sub_repo" --state closed \
             --json number,title,closedAt,labels,url --limit 200 2>/dev/null \
-            | jq '.' > "$_sub_dir/closed-issues.json" || echo "[]" > "$_sub_dir/closed-issues.json"
+            | jq '.' > "$_sub_dir/closed-issues.json" \
+            || echo "[]" > "$_sub_dir/closed-issues.json"
 
         # Open PRs
         gh pr list --repo "$_sub_repo" --state open \
             --json number,title,labels,headRefName,url 2>/dev/null \
-            | jq '.' > "$_sub_dir/open-prs.json" || echo "[]" > "$_sub_dir/open-prs.json"
+            | jq '.' > "$_sub_dir/open-prs.json" \
+            || echo "[]" > "$_sub_dir/open-prs.json"
 
         # Open issues
         gh issue list --repo "$_sub_repo" --state open \
             --json number,title,labels,url 2>/dev/null \
-            | jq '.' > "$_sub_dir/open-issues.json" || echo "[]" > "$_sub_dir/open-issues.json"
+            | jq '.' > "$_sub_dir/open-issues.json" \
+            || echo "[]" > "$_sub_dir/open-issues.json"
 
-        _sub_merged=$(jq 'length' "$_sub_dir/merged-prs.json" 2>/dev/null || echo "0")
-        _sub_closed=$(jq 'length' "$_sub_dir/closed-issues.json" 2>/dev/null || echo "0")
-        _sub_open_prs=$(jq 'length' "$_sub_dir/open-prs.json" 2>/dev/null || echo "0")
-        _sub_intake=$(jq '[.[] | select(.labels[]?.name == "intake:filed")] | length' \
-            "$_sub_dir/open-issues.json" 2>/dev/null || echo "0")
+        _sub_merged=$(jq 'length'                                                    "$_sub_dir/merged-prs.json"    2>/dev/null || echo "0")
+        _sub_closed=$(jq 'length'                                                    "$_sub_dir/closed-issues.json" 2>/dev/null || echo "0")
+        _sub_open_prs=$(jq 'length'                                                  "$_sub_dir/open-prs.json"      2>/dev/null || echo "0")
+        _sub_open_issues=$(jq 'length'                                               "$_sub_dir/open-issues.json"   2>/dev/null || echo "0")
+        _sub_intake=$(jq '[.[] | select(.labels[]?.name == "intake:filed")] | length' "$_sub_dir/open-issues.json"   2>/dev/null || echo "0")
 
         echo "[worker]     $_sub_repo: merged_prs=$_sub_merged closed_issues=$_sub_closed open_prs=$_sub_open_prs intake:filed=$_sub_intake"
 
+        _sub_entry=$(jq -n \
+            --arg  repo         "$_sub_repo" \
+            --arg  name         "$_sub_name" \
+            --arg  github_url   "https://github.com/$_sub_repo" \
+            --arg  reports_url  "https://$_sub_owner.github.io/$_sub_name/" \
+            --arg  data_dir     "$_sub_dir" \
+            --argjson prs_merged    "$_sub_merged" \
+            --argjson issues_closed "$_sub_closed" \
+            --argjson open_prs      "$_sub_open_prs" \
+            --argjson open_issues   "$_sub_open_issues" \
+            --argjson intake_filed  "$_sub_intake" \
+            '{repo:$repo,name:$name,github_url:$github_url,reports_url:$reports_url,
+              data_dir:$data_dir,is_meta:false,prs_merged:$prs_merged,
+              issues_closed:$issues_closed,open_prs:$open_prs,
+              open_issues:$open_issues,intake_filed:$intake_filed}')
+        _index_entries=$(echo "$_index_entries" | jq --argjson e "$_sub_entry" '. + [$e]')
+
+        _total_merged=$(( _total_merged + _sub_merged ))
+        _total_closed=$(( _total_closed + _sub_closed ))
+        _total_open_prs=$(( _total_open_prs + _sub_open_prs ))
+        _total_intake=$(( _total_intake + _sub_intake ))
+
         _sub_repo_summary="${_sub_repo_summary}
-- \`$_sub_repo\`: ${_sub_merged} PRs merged, ${_sub_closed} issues closed, ${_sub_open_prs} open PRs, ${_sub_intake} filed — data: \`$_sub_dir/\`"
+- \`$_sub_repo\`: ${_sub_merged} PRs merged, ${_sub_closed} issues closed, ${_sub_open_prs} open PRs, ${_sub_intake} filed"
     done
+
+    # ── Write pre-computed aggregate files ────────────────────────────────
+    # meta-index.json: one object per repo with stats + github_url + reports_url + data_dir
+    # meta-stats.json: single object with fleet-wide totals
+    echo "$_index_entries" > /tmp/scout-data/meta-index.json
+
+    jq -n \
+        --argjson merged   "$_total_merged" \
+        --argjson closed   "$_total_closed" \
+        --argjson open_prs "$_total_open_prs" \
+        --argjson intake   "$_total_intake" \
+        '{total_prs_merged:$merged,total_issues_closed:$closed,total_open_prs:$open_prs,total_intake_filed:$intake}' \
+        > /tmp/scout-data/meta-stats.json
+
+    echo "[worker]   Meta totals: merged=$_total_merged closed=$_total_closed open_prs=$_total_open_prs intake=$_total_intake"
 fi
 
 # ── Build startup context for situation report ───────────────────────────────
@@ -268,9 +339,19 @@ if [ "$_is_meta_report" = true ]; then
 
 **Mode: META-REPORT** — Follow \`/worker/agents/tasks/generate-meta-report.md\` instead of \`generate-report.md\`.
 
-**Subordinate repos (data pre-gathered):**${_sub_repo_summary}
+**Aggregate totals across all repos:**
+- PRs merged: ${_total_merged}
+- Issues closed: ${_total_closed}
+- Open PRs: ${_total_open_prs}
+- Filed issues (intake:filed): ${_total_intake}
 
-Each subordinate repo's data directory contains the same files as the meta repo:
+**Repos in this meta-report (meta repo first, then subordinates):**${_sub_repo_summary}
+
+**Pre-computed files (read these — no arithmetic needed):**
+- \`/tmp/scout-data/meta-index.json\` — array of repo objects; each has: \`repo\`, \`name\`, \`github_url\`, \`reports_url\` (GitHub Pages Scout reports), \`data_dir\`, \`is_meta\`, \`prs_merged\`, \`issues_closed\`, \`open_prs\`, \`open_issues\`, \`intake_filed\`
+- \`/tmp/scout-data/meta-stats.json\` — fleet-wide totals: \`total_prs_merged\`, \`total_issues_closed\`, \`total_open_prs\`, \`total_intake_filed\`
+
+Each repo's activity data is at its \`data_dir\` (same file structure as the meta repo):
 \`git-log.txt\`, \`merged-prs.json\`, \`closed-issues.json\`, \`open-prs.json\`, \`open-issues.json\`."
 fi
 

--- a/worker/scripts/scout/startup.sh
+++ b/worker/scripts/scout/startup.sh
@@ -173,17 +173,18 @@ echo "$_closed_issues" | jq '.' > /tmp/scout-data/closed-issues.json
 echo "$_open_prs" | jq '.' > /tmp/scout-data/open-prs.json
 echo "$_open_issues" | jq '.' > /tmp/scout-data/open-issues.json
 
-# ── Gather subordinate repo data (meta-report mode) ──────────────────────────
-# When SCOUT_SUBORDINATE_REPOS is set, fetch data for each subordinate repo
-# using the GitHub API, then pre-compute aggregate stats and a repo index so
-# Claude only needs to synthesize narratives and group themes — no arithmetic.
+# ── Fetch sub-scout reports (meta-report mode) ───────────────────────────────
+# When SCOUT_SUB_SCOUTS is set, read each sub-scout's already-generated
+# data.json rather than re-fetching raw GitHub data. Three API calls per
+# sub-scout: config → directory listing → report file.
 _is_meta_report=false
 _sub_repo_summary=""
+_missing_scouts=""
 
-if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
+if [ -n "${SCOUT_SUB_SCOUTS:-}" ]; then
     _is_meta_report=true
-    echo "[worker]   Meta-report mode: gathering data for subordinate repos..."
-    mkdir -p /tmp/scout-data/repos
+    echo "[worker]   Meta-report mode: reading sub-scout reports..."
+    mkdir -p /tmp/scout-data/subordinates
 
     # ── Seed meta-index with the meta repo entry ─────────────────────────
     _meta_owner=$(echo "$TARGET_REPO" | cut -d/ -f1)
@@ -202,8 +203,8 @@ if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
         --argjson open_issues   "$_new_issues_count" \
         --argjson intake_filed  "$_intake_count" \
         '[{repo:$repo,name:$name,github_url:$github_url,reports_url:$reports_url,
-           data_dir:$data_dir,is_meta:true,prs_merged:$prs_merged,
-           issues_closed:$issues_closed,open_prs:$open_prs,
+           data_dir:$data_dir,is_meta:true,has_report:true,report_date:"current",
+           prs_merged:$prs_merged,issues_closed:$issues_closed,open_prs:$open_prs,
            open_issues:$open_issues,intake_filed:$intake_filed}]')
 
     _total_merged=$_merged_prs_count
@@ -211,83 +212,96 @@ if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
     _total_open_prs=$_meta_open_prs_count
     _total_intake=$_intake_count
 
-    # ── Fetch each subordinate repo and append to index ───────────────────
-    for _sub_repo in $SCOUT_SUBORDINATE_REPOS; do
+    # ── Fetch each sub-scout's latest data.json ───────────────────────────
+    for _entry in $SCOUT_SUB_SCOUTS; do
+        _sub_repo=$(echo "$_entry" | cut -d'|' -f1)
+        _sub_scout_dir=$(echo "$_entry" | cut -d'|' -f2)
         _sub_owner=$(echo "$_sub_repo" | cut -d/ -f1)
         _sub_name=$(echo "$_sub_repo" | cut -d/ -f2)
-        _sub_dir="/tmp/scout-data/repos/$_sub_owner/$_sub_name"
+        _sub_dir="/tmp/scout-data/subordinates/$_sub_owner/$_sub_name"
         mkdir -p "$_sub_dir"
 
-        echo "[worker]     Fetching: $_sub_repo"
+        echo "[worker]     Sub-scout: $_sub_repo (scout_dir: $_sub_scout_dir)"
 
-        # Commits via GitHub API (since baseline date)
-        gh api --paginate \
-            "repos/$_sub_repo/commits?since=${_baseline_date}T00:00:00Z&per_page=100" \
-            --jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"' \
-            2>/dev/null > "$_sub_dir/git-log.txt" \
-            || echo "(no commits)" > "$_sub_dir/git-log.txt"
+        # 1. Read the sub-scout's config to find its reports_dir
+        _sub_config_b64=$(gh api "repos/$_sub_repo/contents/$_sub_scout_dir/config.yaml" \
+            --jq '.content // empty' 2>/dev/null || echo "")
+        if [ -n "$_sub_config_b64" ]; then
+            _sub_reports_dir=$(printf '%s' "$_sub_config_b64" | base64 -d 2>/dev/null \
+                | yq '.reports_dir // "docs/reports"' 2>/dev/null || echo "docs/reports")
+        else
+            _sub_reports_dir="docs/reports"
+            echo "[worker]       no scout config found — defaulting reports_dir to docs/reports"
+        fi
 
-        # Merged PRs
-        gh pr list --repo "$_sub_repo" --state merged \
-            --json number,title,mergedAt,author,body,url --limit 200 2>/dev/null \
-            | jq '.' > "$_sub_dir/merged-prs.json" \
-            || echo "[]" > "$_sub_dir/merged-prs.json"
+        # 2. Find the latest report date folder
+        _latest_date=$(gh api "repos/$_sub_repo/contents/$_sub_reports_dir" \
+            --jq '[.[] | select(.type=="dir") | .name] | sort | last // empty' \
+            2>/dev/null || echo "")
 
-        # Closed issues
-        gh issue list --repo "$_sub_repo" --state closed \
-            --json number,title,closedAt,labels,url --limit 200 2>/dev/null \
-            | jq '.' > "$_sub_dir/closed-issues.json" \
-            || echo "[]" > "$_sub_dir/closed-issues.json"
+        # 3. Fetch the report file
+        _has_report=false
+        _report_date=""
+        _sub_merged=0; _sub_closed=0; _sub_open_prs=0; _sub_intake=0
 
-        # Open PRs
-        gh pr list --repo "$_sub_repo" --state open \
-            --json number,title,labels,headRefName,url 2>/dev/null \
-            | jq '.' > "$_sub_dir/open-prs.json" \
-            || echo "[]" > "$_sub_dir/open-prs.json"
+        if [ -n "$_latest_date" ]; then
+            _report_b64=$(gh api \
+                "repos/$_sub_repo/contents/$_sub_reports_dir/$_latest_date/data.json" \
+                --jq '.content // empty' 2>/dev/null || echo "")
+            if [ -n "$_report_b64" ]; then
+                if printf '%s' "$_report_b64" | base64 -d 2>/dev/null \
+                        > "$_sub_dir/latest-report.json"; then
+                    _has_report=true
+                    _report_date="$_latest_date"
+                    # Extract stats from the child's SprintReport summary
+                    _sub_merged=$(jq '.summary.stats[] | select(.label=="PRs Merged")    | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_closed=$(jq '.summary.stats[] | select(.label=="Issues Closed") | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_open_prs=$(jq '.summary.stats[] | select(.label=="Open PRs")    | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    _sub_intake=$(jq '.summary.stats[] | select(.label=="Filed Issues")  | .value // 0' "$_sub_dir/latest-report.json" 2>/dev/null || echo "0")
+                    echo "[worker]       report from $_report_date — merged=$_sub_merged closed=$_sub_closed open_prs=$_sub_open_prs intake=$_sub_intake"
+                fi
+            fi
+        fi
 
-        # Open issues
-        gh issue list --repo "$_sub_repo" --state open \
-            --json number,title,labels,url 2>/dev/null \
-            | jq '.' > "$_sub_dir/open-issues.json" \
-            || echo "[]" > "$_sub_dir/open-issues.json"
-
-        _sub_merged=$(jq 'length'                                                    "$_sub_dir/merged-prs.json"    2>/dev/null || echo "0")
-        _sub_closed=$(jq 'length'                                                    "$_sub_dir/closed-issues.json" 2>/dev/null || echo "0")
-        _sub_open_prs=$(jq 'length'                                                  "$_sub_dir/open-prs.json"      2>/dev/null || echo "0")
-        _sub_open_issues=$(jq 'length'                                               "$_sub_dir/open-issues.json"   2>/dev/null || echo "0")
-        _sub_intake=$(jq '[.[] | select(.labels[]?.name == "intake:filed")] | length' "$_sub_dir/open-issues.json"   2>/dev/null || echo "0")
-
-        echo "[worker]     $_sub_repo: merged_prs=$_sub_merged closed_issues=$_sub_closed open_prs=$_sub_open_prs intake:filed=$_sub_intake"
+        if [ "$_has_report" = false ]; then
+            echo "[worker]       ⚠ no report available yet"
+            _missing_scouts="${_missing_scouts} $_sub_repo"
+        fi
 
         _sub_entry=$(jq -n \
-            --arg  repo         "$_sub_repo" \
-            --arg  name         "$_sub_name" \
-            --arg  github_url   "https://github.com/$_sub_repo" \
-            --arg  reports_url  "https://$_sub_owner.github.io/$_sub_name/" \
-            --arg  data_dir     "$_sub_dir" \
+            --arg  repo        "$_sub_repo" \
+            --arg  name        "$_sub_name" \
+            --arg  github_url  "https://github.com/$_sub_repo" \
+            --arg  reports_url "https://$_sub_owner.github.io/$_sub_name/" \
+            --arg  data_dir    "$_sub_dir" \
+            --arg  report_date "${_report_date:-}" \
+            --arg  report_file "${_sub_dir}/latest-report.json" \
+            --argjson has_report    "$_has_report" \
             --argjson prs_merged    "$_sub_merged" \
             --argjson issues_closed "$_sub_closed" \
             --argjson open_prs      "$_sub_open_prs" \
-            --argjson open_issues   "$_sub_open_issues" \
             --argjson intake_filed  "$_sub_intake" \
             '{repo:$repo,name:$name,github_url:$github_url,reports_url:$reports_url,
-              data_dir:$data_dir,is_meta:false,prs_merged:$prs_merged,
-              issues_closed:$issues_closed,open_prs:$open_prs,
-              open_issues:$open_issues,intake_filed:$intake_filed}')
+              data_dir:$data_dir,is_meta:false,has_report:$has_report,
+              report_date:$report_date,report_file:$report_file,
+              prs_merged:$prs_merged,issues_closed:$issues_closed,
+              open_prs:$open_prs,intake_filed:$intake_filed}')
         _index_entries=$(echo "$_index_entries" | jq --argjson e "$_sub_entry" '. + [$e]')
 
-        _total_merged=$(( _total_merged + _sub_merged ))
-        _total_closed=$(( _total_closed + _sub_closed ))
-        _total_open_prs=$(( _total_open_prs + _sub_open_prs ))
-        _total_intake=$(( _total_intake + _sub_intake ))
-
-        _sub_repo_summary="${_sub_repo_summary}
-- \`$_sub_repo\`: ${_sub_merged} PRs merged, ${_sub_closed} issues closed, ${_sub_open_prs} open PRs, ${_sub_intake} filed"
+        if [ "$_has_report" = true ]; then
+            _total_merged=$(( _total_merged + _sub_merged ))
+            _total_closed=$(( _total_closed + _sub_closed ))
+            _total_open_prs=$(( _total_open_prs + _sub_open_prs ))
+            _total_intake=$(( _total_intake + _sub_intake ))
+            _sub_repo_summary="${_sub_repo_summary}
+- \`$_sub_repo\`: report from ${_report_date} — ${_sub_merged} PRs merged, ${_sub_closed} issues closed, ${_sub_open_prs} open PRs, ${_sub_intake} filed"
+        else
+            _sub_repo_summary="${_sub_repo_summary}
+- \`$_sub_repo\`: ⚠ no report available yet"
+        fi
     done
 
     # ── Write pre-computed aggregate files ────────────────────────────────
-    # meta-index.json: one object per repo with stats + github_url + reports_url + data_dir
-    # meta-stats.json: single object with fleet-wide totals
     echo "$_index_entries" > /tmp/scout-data/meta-index.json
 
     jq -n \
@@ -295,10 +309,13 @@ if [ -n "${SCOUT_SUBORDINATE_REPOS:-}" ]; then
         --argjson closed   "$_total_closed" \
         --argjson open_prs "$_total_open_prs" \
         --argjson intake   "$_total_intake" \
-        '{total_prs_merged:$merged,total_issues_closed:$closed,total_open_prs:$open_prs,total_intake_filed:$intake}' \
+        '{total_prs_merged:$merged,total_issues_closed:$closed,
+          total_open_prs:$open_prs,total_intake_filed:$intake}' \
         > /tmp/scout-data/meta-stats.json
 
+    _missing_scouts=$(echo "$_missing_scouts" | xargs)  # trim whitespace
     echo "[worker]   Meta totals: merged=$_total_merged closed=$_total_closed open_prs=$_total_open_prs intake=$_total_intake"
+    [ -n "$_missing_scouts" ] && echo "[worker]   Missing sub-scout reports: $_missing_scouts"
 fi
 
 # ── Build startup context for situation report ───────────────────────────────
@@ -331,7 +348,7 @@ do not re-fetch from GitHub or git.
 with \`next_report_date: \"${_next_report_date}\"\`. Commit both the report and the
 config update in the same commit."
 
-# Append meta-report section when subordinate repos are configured
+# Append meta-report section when sub-scouts are configured
 if [ "$_is_meta_report" = true ]; then
     _startup_context="${_startup_context}
 
@@ -339,20 +356,21 @@ if [ "$_is_meta_report" = true ]; then
 
 **Mode: META-REPORT** — Follow \`/worker/agents/tasks/generate-meta-report.md\` instead of \`generate-report.md\`.
 
-**Aggregate totals across all repos:**
+**Aggregate totals (meta repo + sub-scouts with available reports):**
 - PRs merged: ${_total_merged}
 - Issues closed: ${_total_closed}
 - Open PRs: ${_total_open_prs}
 - Filed issues (intake:filed): ${_total_intake}
 
-**Repos in this meta-report (meta repo first, then subordinates):**${_sub_repo_summary}
+**Sub-scouts:**${_sub_repo_summary}
 
-**Pre-computed files (read these — no arithmetic needed):**
-- \`/tmp/scout-data/meta-index.json\` — array of repo objects; each has: \`repo\`, \`name\`, \`github_url\`, \`reports_url\` (GitHub Pages Scout reports), \`data_dir\`, \`is_meta\`, \`prs_merged\`, \`issues_closed\`, \`open_prs\`, \`open_issues\`, \`intake_filed\`
+**Missing sub-scout reports:** ${_missing_scouts:-none}
+
+**Pre-computed files:**
+- \`/tmp/scout-data/meta-index.json\` — one object per repo with: \`repo\`, \`name\`, \`github_url\`, \`reports_url\` (GitHub Pages), \`data_dir\`, \`is_meta\`, \`has_report\`, \`report_date\`, \`report_file\` (path to fetched data.json, when \`has_report\` is true), \`prs_merged\`, \`issues_closed\`, \`open_prs\`, \`intake_filed\`
 - \`/tmp/scout-data/meta-stats.json\` — fleet-wide totals: \`total_prs_merged\`, \`total_issues_closed\`, \`total_open_prs\`, \`total_intake_filed\`
 
-Each repo's activity data is at its \`data_dir\` (same file structure as the meta repo):
-\`git-log.txt\`, \`merged-prs.json\`, \`closed-issues.json\`, \`open-prs.json\`, \`open-issues.json\`."
+Sub-scout reports are at each entry's \`report_file\` path (SprintReport JSON — already summarized by that Scout)."
 fi
 
 # Export for use by the agent


### PR DESCRIPTION
Adds a `sub_scouts` config option to `.agents/scout/config.yaml`.
When set, Scout fetches each sub-scout's already-generated `data.json`
report (3 API calls per repo) and produces a combined SprintReport
covering the meta repo's own activity plus a summary section per
sub-scout.

## Changes

- **`worker/scripts/common.sh`**: export `SCOUT_SUB_SCOUTS` from per-agent config — supports plain `"owner/repo"` strings or objects with an optional `scout_dir` override (default `.agents/scout/`)
- **`worker/scripts/scout/startup.sh`**: when sub-scouts are configured, fetch each child's `config.yaml` → `reports_dir`, list that directory to find the latest date, fetch `data.json`; write pre-computed `meta-index.json` and `meta-stats.json` to `/tmp/scout-data/`; set `Mode: META-REPORT` in the situation report
- **`agents/tasks/generate-meta-report.md`**: new task — reads pre-computed index/stats, builds a SprintReport with the meta repo's own activity as themes plus one summary theme per sub-scout (highlights + top-3 themes + link to full report); missing sub-scouts get a "Report Pending" placeholder and a PR comment
- **`agents/scout.md`**: route to `generate-meta-report.md` when situation report shows `Mode: META-REPORT`, otherwise use `generate-report.md` as before
- **`worker/scripts/scout/init.sh`**: add `sub_scouts` placeholder comment in the generated `config.yaml` (plain string and object-with-scout_dir examples)
- **`.github/workflows/build-worker.yml`**: switch Docker buildx to GHA cache backend (`type=gha`) to prevent transient "unknown blob" failures from stale inline registry cache

https://claude.ai/code/session_01JcVmGqGQ7ipxNTuBHtrCsW